### PR TITLE
fix: stretching accuracy input, output 타입 수정

### DIFF
--- a/packages/stretching-accuracy/src/engine/create-accuracy-engine.ts
+++ b/packages/stretching-accuracy/src/engine/create-accuracy-engine.ts
@@ -1,4 +1,9 @@
-import type { AccuracyEngine, AccuracyEvaluateInput, AccuracyResult } from '../types';
+import type {
+  AccuracyEngine,
+  AccuracyEvaluateInput,
+  AccuracyResult,
+  CountedStatus,
+} from '../types';
 
 /**
  * @description ai 정확도 구현 로직
@@ -8,7 +13,13 @@ import type { AccuracyEngine, AccuracyEvaluateInput, AccuracyResult } from '../t
  */
 
 const evaluate = (_input: AccuracyEvaluateInput): AccuracyResult => {
-  return { score: 0 };
+  const counted: CountedStatus = _input.type === 'REPS' ? 'NOT_INCREMENTED' : 'NOT_APPLICABLE';
+
+  return {
+    score: 0,
+    phase: _input.phase,
+    counted,
+  };
 };
 
 export function createAccuracyEngine(): AccuracyEngine {

--- a/packages/stretching-accuracy/src/index.ts
+++ b/packages/stretching-accuracy/src/index.ts
@@ -3,6 +3,8 @@ export type {
   AccuracyEngine,
   AccuracyEvaluateInput,
   AccuracyResult,
+  CountedStatus,
+  ExerciseType,
   Landmark2D,
   PoseFrame,
   ReferenceKeyframe,

--- a/packages/stretching-accuracy/src/types.ts
+++ b/packages/stretching-accuracy/src/types.ts
@@ -9,6 +9,10 @@ export type PoseFrame = {
   timestampMs: number;
   landmarks: ReadonlyArray<Landmark2D>;
 };
+export type ExerciseType = 'DURATION' | 'REPS';
+
+export type CountedStatus = 'INCREMENTED' | 'NOT_INCREMENTED' | 'NOT_APPLICABLE';
+
 //서버에서 받아오는 keyframe 데이터
 export type ReferenceKeyframe = {
   phase: string;
@@ -27,10 +31,14 @@ export type AccuracyEvaluateInput = {
   frame: PoseFrame;
   referencePose: ReferencePose;
   progressRatio: number;
+  type: ExerciseType;
+  phase: string;
 };
 
 export type AccuracyResult = {
   score: number;
+  phase: string;
+  counted: CountedStatus;
   meta?: Readonly<Record<string, unknown>>;
 };
 

--- a/packages/stretching-session/src/create-session.ts
+++ b/packages/stretching-session/src/create-session.ts
@@ -2,6 +2,7 @@ import {
   createAccuracyEngine,
   type AccuracyEngine,
   type AccuracyResult,
+  type ExerciseType,
   type PoseFrame,
   type ReferencePose,
   type Landmark2D,
@@ -18,6 +19,8 @@ export type CreateSessionOptions = {
   wasmRoot: string;
   referencePose: ReferencePose;
   getProgressRatio: () => number;
+  exerciseType: ExerciseType;
+  getPhase: () => string;
   onFrame?: (frame: PoseFrame) => void;
   onAccuracy?: (result: AccuracyResult, frame: PoseFrame) => void;
   onError?: (error: Error) => void;
@@ -65,6 +68,8 @@ export function createSession(options: CreateSessionOptions): StretchingSession 
     wasmRoot,
     referencePose,
     getProgressRatio,
+    exerciseType,
+    getPhase,
     onFrame,
     onAccuracy,
     onError,
@@ -129,7 +134,14 @@ export function createSession(options: CreateSessionOptions): StretchingSession 
 
       // TODO: 세션 내부에서 정확도 평가 진행(진행률 정책 확정 후 외부 이동 검토 for 관심사 분리)
       const progressRatio = getProgressRatio();
-      const accuracy = accuracyEngine.evaluate({ frame, referencePose, progressRatio });
+      const phase = getPhase();
+      const accuracy = accuracyEngine.evaluate({
+        frame,
+        referencePose,
+        progressRatio,
+        type: exerciseType,
+        phase,
+      });
       onAccuracy?.(accuracy, frame);
     }
 


### PR DESCRIPTION
🔷 Github Issue ID

- [작업한 내용에 해당하는 Issue 링크](https://github.com/100-hours-a-week/1-team-one-wiki/issues/230#issue-3850226130)
댓글 사항 반영

📌 작업 내용 및 특이사항

- api get 으로 받아오는 세션 reference 비교용 데이터 input 으로 추가
- ai파트와 논의 후 input, output 타입 추가

📚 참고사항

- PR 리뷰 과정에서 참고하면 좋을 내용들


