### PR TITLE
[#102] fix: 스트레칭 실패 기준 수정, 실패 화면 style 수정

### DIFF
--- a/apps/web/src/features/stretching-session/config/messages.ts
+++ b/apps/web/src/features/stretching-session/config/messages.ts
@@ -30,7 +30,7 @@ export const STRETCHING_SESSION_MESSAGES = {
       },
       FAILURE: {
         TITLE: '스트레칭 실패',
-        LABEL: '바쁘신가요? 알람 수정을 통해 알람을 조정할 수 있어요.',
+        LABEL: `바쁘신가요?\n알람 수정을 통해 알람을 조정할 수 있어요.`,
         IMAGE_ALT: '스트레칭 실패 결과 이미지',
       },
     },

--- a/apps/web/src/features/stretching-session/ui/StretchingSessionCompletionResult.tsx
+++ b/apps/web/src/features/stretching-session/ui/StretchingSessionCompletionResult.tsx
@@ -44,9 +44,9 @@ export const STRETCHING_RESULT_UI: Record<StretchingResultStatus, StretchingResu
     label: STRETCHING_SESSION_MESSAGES.RESULT.STATUS.FAILURE.LABEL,
     imageSrc: '/images/stretch/result_fail.png',
     color: {
-      bgClass: 'bg-danger-50',
-      textClass: 'text-danger-700',
-      badgeClass: 'bg-danger-100 text-danger-800',
+      bgClass: 'bg-error-50',
+      textClass: 'text-error-700',
+      badgeClass: 'bg-error-100 text-error-800',
     },
   },
 };
@@ -66,7 +66,7 @@ export function StretchingSessionCompletionResult({
     );
   }
 
-  const isSuccess = result.isCompleted;
+  const isSuccess = result.earnedExp > 0; //isCompleted 는 완료 시에 모두 true, 성공 실패 여부와는 다르다.
   const statusKey: StretchingResultStatus = isSuccess ? 'success' : 'failure';
   const uiConfig = STRETCHING_RESULT_UI[statusKey];
   const safeEarnedExp = Math.max(0, result.earnedExp);

--- a/apps/web/src/features/stretching-session/ui/StretchingSessionResultStatusCard.tsx
+++ b/apps/web/src/features/stretching-session/ui/StretchingSessionResultStatusCard.tsx
@@ -27,7 +27,9 @@ export function StretchingSessionResultStatusCard({
       className={`animate-result-pop flex flex-col items-center gap-3 rounded-lg px-4 py-5 ${color.bgClass}`}
     >
       <Chip label={title} size="sm" className={`text-xs font-semibold ${color.badgeClass}`} />
-      <p className={`text-base font-semibold ${color.textClass}`}>{label}</p>
+      <p className={`text-base font-semibold ${color.textClass} text-center whitespace-pre`}>
+        {label}
+      </p>
       <Image src={imageSrc} alt={imageAlt} width={220} height={160} priority />
     </div>
   );


### PR DESCRIPTION
🔷 Github Issue ID

- #102

📌 작업 내용 및 특이사항

- `result.isCompleted;` 는 완료 시 모두 true 임을 확인 (성공 / 실패 여부 판단 기준 x)
- earnedExp >0 일 시 성공으로 판별하도록 수정
- 백엔드측에서 오류 수정 중 (earnedExp>0 일 때 notifications 조회 시 성공했습니다! 올라오는 현상 수정 중)

📚 참고사항

- PR 리뷰 과정에서 참고하면 좋을 내용들

Closes #102
