### PR TITLE
[#59] 공통 로딩 설정 추가하여 loading fallback 구현

### DIFF
--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -1,10 +1,13 @@
 import '@/styles/globals.css';
 
 import { withProviders } from '@/src/providers/withProviders';
+import { useRouteLoading } from '@/src/shared/model/loading';
 import type { AppPropsWithLayout } from '@/src/shared/types';
 import { ErrorBoundary } from '@/src/shared/ui/error-boundary';
+import { GlobalLoadingOverlay } from '@/src/shared/ui/loading';
 
 function App({ Component, pageProps }: AppPropsWithLayout) {
+  useRouteLoading();
   const getLayout = Component.getLayout ?? ((page) => page);
 
   return (
@@ -16,6 +19,7 @@ function App({ Component, pageProps }: AppPropsWithLayout) {
         void info;
       }}
     >
+      <GlobalLoadingOverlay />
       {getLayout(<Component {...pageProps} />)}
     </ErrorBoundary>
   );

--- a/apps/web/src/features/auth/login/ui/LoginForm.tsx
+++ b/apps/web/src/features/auth/login/ui/LoginForm.tsx
@@ -37,6 +37,7 @@ export function LoginForm({ onSubmit, isPending }: LoginFormProps) {
   const emailValue = useWatch({ control, name: 'email' });
   const passwordValue = useWatch({ control, name: 'password' });
   const isSubmitDisabled = isPending || formState.isSubmitting;
+  const isSubmitLoading = isSubmitDisabled;
 
   useClearFieldErrorsOnChange({
     control,
@@ -128,7 +129,7 @@ export function LoginForm({ onSubmit, isPending }: LoginFormProps) {
         )}
       </div>
 
-      <Button type="submit" disabled={isSubmitDisabled}>
+      <Button type="submit" disabled={isSubmitDisabled} isLoading={isSubmitLoading}>
         {LOGIN_FORM_MESSAGES.BUTTON.SUBMIT}
       </Button>
     </form>

--- a/apps/web/src/features/auth/signup/ui/SignupForm.tsx
+++ b/apps/web/src/features/auth/signup/ui/SignupForm.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { Button } from '@repo/ui/button';
 import { InputImage } from '@repo/ui/input-image';
 import { Controller, useForm, type UseFormSetError } from 'react-hook-form';
 
@@ -41,6 +42,7 @@ export function SignupForm({ onSubmit, isPending, isProfileImageUploading }: Sig
 
   const emailDup = useEmailDuplication(control, setError, clearErrors);
   const nicknameDup = useNicknameDuplication(control, setError, clearErrors);
+  const isSubmitLoading = Boolean(isPending || formState.isSubmitting);
 
   const handleFormSubmit = async (values: SignupFormValues) => {
     const isEmailAvailable = emailDup.state.status === 'available';
@@ -94,7 +96,7 @@ export function SignupForm({ onSubmit, isPending, isProfileImageUploading }: Sig
       onSubmit={handleSubmit(handleFormSubmit)}
       className="flex w-full flex-col justify-center gap-6"
     >
-      {/* TODO: 설정 모아서 map 으로 변경 */}
+      {/* TODO: 설정 모아서 맵으로 변경 */}
       <Controller
         name="profileImage"
         control={control}
@@ -208,13 +210,9 @@ export function SignupForm({ onSubmit, isPending, isProfileImageUploading }: Sig
         <p className="text-error-600 text-sm">{formState.errors.root.serverError.message}</p>
       )}
 
-      <button
-        type="submit"
-        disabled={isPending || formState.isSubmitting}
-        className="bg-brand-600 hover:bg-brand-700 w-full rounded-md px-4 py-2 text-white disabled:cursor-not-allowed disabled:opacity-50"
-      >
-        {isPending || formState.isSubmitting ? '처리 중...' : '회원가입'}
-      </button>
+      <Button type="submit" fullWidth isLoading={isSubmitLoading}>
+        {isSubmitLoading ? '처리 중' : '회원가입'}
+      </Button>
     </form>
   );
 }

--- a/apps/web/src/features/notifications/config/messages.ts
+++ b/apps/web/src/features/notifications/config/messages.ts
@@ -11,6 +11,8 @@ export const NOTIFICATIONS_MESSAGES = {
     EMPTY: '아직 정보가 없습니다',
     LOADING: '불러오는 중...',
     FETCHING_MORE: '추가 알림 불러오는 중...',
+    ERROR: '알림을 불러오지 못했습니다.',
+    WARNING: '일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
   },
   META: {
     DETAILS_EMPTY: '-',

--- a/apps/web/src/features/notifications/ui/NotificationList.skeleton.tsx
+++ b/apps/web/src/features/notifications/ui/NotificationList.skeleton.tsx
@@ -1,0 +1,28 @@
+import { Shimmer } from '@repo/ui/shimmer';
+import { SkeletonCard } from '@repo/ui/skeleton-card';
+import { SkeletonText } from '@repo/ui/skeleton-text';
+
+export function NotificationListSkeleton() {
+  return (
+    <Shimmer>
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-3">
+          <SkeletonText lines={1} widths={['20%']} />
+          <SkeletonCard height="80px" padding="md" />
+          <SkeletonCard height="80px" padding="md" />
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <SkeletonText lines={1} widths={['25%']} />
+          <SkeletonCard height="80px" padding="md" />
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <SkeletonText lines={1} widths={['22%']} />
+          <SkeletonCard height="80px" padding="md" />
+          <SkeletonCard height="80px" padding="md" />
+        </div>
+      </div>
+    </Shimmer>
+  );
+}

--- a/apps/web/src/features/onboarding-alarm-settings/ui/NotificationSettingsForm.tsx
+++ b/apps/web/src/features/onboarding-alarm-settings/ui/NotificationSettingsForm.tsx
@@ -210,7 +210,7 @@ export function NotificationSettingsForm({
           />
         </CardContent>
       </Card>
-      <Button type="submit" disabled={formState.isSubmitting} fullWidth>
+      <Button type="submit" isLoading={formState.isSubmitting} fullWidth>
         {formState.isSubmitting ? '저장 중...' : submitLabel}
       </Button>
     </form>

--- a/apps/web/src/features/onboarding-survey/config/messages.ts
+++ b/apps/web/src/features/onboarding-survey/config/messages.ts
@@ -5,4 +5,6 @@ export const SURVEY_MESSAGES = {
   NEXT: '다음으로',
   LOADING: '설문을 불러오는 중입니다.',
   ERROR: '설문을 불러오지 못했습니다.',
+  EMPTY: '표시할 설문이 없습니다.',
+  QUESTION_HELPER: '아래 항목 중 하나만 선택해주세요',
 } as const;

--- a/apps/web/src/features/onboarding-survey/ui/OnboardingSurveyForm.skeleton.tsx
+++ b/apps/web/src/features/onboarding-survey/ui/OnboardingSurveyForm.skeleton.tsx
@@ -1,0 +1,33 @@
+import { Shimmer } from '@repo/ui/shimmer';
+import { Skeleton } from '@repo/ui/skeleton';
+import { SkeletonCard } from '@repo/ui/skeleton-card';
+import { SkeletonText } from '@repo/ui/skeleton-text';
+
+const OPTION_COUNT = 4;
+
+export function OnboardingSurveyFormSkeleton() {
+  return (
+    <Shimmer>
+      <div className="flex h-full flex-col justify-evenly gap-20 p-6">
+        <header className="flex flex-col items-center gap-2 text-center">
+          <SkeletonText lines={1} widths={['45%']} />
+          <SkeletonText lines={1} widths={['60%']} />
+        </header>
+
+        <div className="flex flex-col gap-4">
+          <SkeletonCard padding="md" className="h-24" />
+          <div className="flex flex-col gap-3">
+            {Array.from({ length: OPTION_COUNT }).map((_, index) => (
+              <Skeleton key={`survey-option-${index}`} className="h-12 w-full rounded-md" />
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-col items-center justify-between gap-3">
+          <Skeleton className="h-10 w-full rounded-lg" />
+          <Skeleton className="h-10 w-full rounded-lg" />
+        </div>
+      </div>
+    </Shimmer>
+  );
+}

--- a/apps/web/src/pages/app-alarm/ui/AppAlarmPage.skeleton.tsx
+++ b/apps/web/src/pages/app-alarm/ui/AppAlarmPage.skeleton.tsx
@@ -1,0 +1,58 @@
+import { Shimmer } from '@repo/ui/shimmer';
+import { Skeleton } from '@repo/ui/skeleton';
+import { SkeletonText } from '@repo/ui/skeleton-text';
+
+const INPUT_ROWS = 4;
+const OPTION_ROWS = 3;
+
+export function AppAlarmPageSkeleton() {
+  return (
+    <Shimmer>
+      <div className="mx-auto flex h-full w-full max-w-2xl flex-col justify-center gap-6 p-6">
+        <div className="border-border rounded-lg border p-6">
+          <div className="space-y-6">
+            <SkeletonText lines={1} widths={['30%']} />
+
+            <div className="space-y-3">
+              <SkeletonText lines={1} widths={['24%']} />
+              <Skeleton className="h-10 w-full rounded-md" />
+            </div>
+
+            <div className="space-y-3">
+              <SkeletonText lines={1} widths={['22%']} />
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <Skeleton className="h-10 w-full rounded-md" />
+                <Skeleton className="h-10 w-full rounded-md" />
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <SkeletonText lines={1} widths={['22%']} />
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <Skeleton className="h-10 w-full rounded-md" />
+                <Skeleton className="h-10 w-full rounded-md" />
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <SkeletonText lines={1} widths={['20%']} />
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: OPTION_ROWS }).map((_, index) => (
+                  <Skeleton key={`weekday-${index}`} className="h-8 w-16 rounded-full" />
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              {Array.from({ length: INPUT_ROWS }).map((_, index) => (
+                <Skeleton key={`row-${index}`} className="h-10 w-full rounded-md" />
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <Skeleton className="h-11 w-full rounded-lg" />
+      </div>
+    </Shimmer>
+  );
+}

--- a/apps/web/src/pages/app-main/ui/AppMainPage.skeleton.tsx
+++ b/apps/web/src/pages/app-main/ui/AppMainPage.skeleton.tsx
@@ -1,0 +1,44 @@
+import { Shimmer } from '@repo/ui/shimmer';
+import { SkeletonAvatar } from '@repo/ui/skeleton-avatar';
+import { SkeletonCard } from '@repo/ui/skeleton-card';
+import { SkeletonText } from '@repo/ui/skeleton-text';
+
+export function AppMainPageSkeleton() {
+  return (
+    <Shimmer>
+      <div className="flex flex-col gap-6 p-6 pb-20">
+        <section aria-label="프로필 상태">
+          <div className="bg-bg border-border flex items-center gap-4 rounded-lg border p-4">
+            <SkeletonAvatar size="lg" />
+            <div className="flex-1 space-y-3">
+              <SkeletonText lines={1} widths={['40%']} />
+              <div className="flex items-center gap-4">
+                <SkeletonText lines={1} widths={['30%']} />
+                <SkeletonText lines={1} widths={['30%']} />
+              </div>
+              <SkeletonCard height="8px" padding="sm" />
+            </div>
+          </div>
+        </section>
+
+        <section className="flex flex-col items-center justify-center gap-2 px-5">
+          <SkeletonCard height="300px" style={{ width: '400px', maxWidth: '100%' }} />
+          <SkeletonText lines={1} widths={['50%']} className="mt-2" />
+        </section>
+
+        <section>
+          <SkeletonCard height="200px" padding="md" />
+        </section>
+
+        <section className="flex gap-3">
+          <div className="flex-1">
+            <SkeletonCard height="140px" padding="md" />
+          </div>
+          <div className="flex-1">
+            <SkeletonCard height="140px" padding="md" />
+          </div>
+        </section>
+      </div>
+    </Shimmer>
+  );
+}

--- a/apps/web/src/pages/app-main/ui/AppMainPage.tsx
+++ b/apps/web/src/pages/app-main/ui/AppMainPage.tsx
@@ -6,6 +6,8 @@ import { useValidExerciseSessionsQuery } from '@/src/features/exercise-session';
 import { transformGrassData, useGrassStatsQuery } from '@/src/features/grass-stats';
 import { useUserProfileQuery } from '@/src/features/user-profile';
 import { buildStretchSessionPath } from '@/src/shared/routes';
+import { LoadableBoundary } from '@/src/shared/ui/boundary';
+import { ErrorScreen } from '@/src/shared/ui/error-screen';
 import { LinkCard } from '@/src/shared/ui/LinkCard';
 import { UserStatusCardSection } from '@/src/widgets/user-status-card';
 
@@ -16,86 +18,113 @@ import {
   getCharacterStatusByStreak,
 } from '../config/character-status';
 import { APP_MAIN_MESSAGES } from '../config/messages';
+import { AppMainPageSkeleton } from './AppMainPage.skeleton';
 
 export function AppMainPage() {
-  const { data } = useUserProfileQuery();
-  const { data: grassData } = useGrassStatsQuery({
+  const userQuery = useUserProfileQuery();
+  const grassQuery = useGrassStatsQuery({
     view: 'WEEKLY',
   });
-  const { data: validSessions } = useValidExerciseSessionsQuery();
+  const validSessionsQuery = useValidExerciseSessionsQuery();
 
-  const characterStatus = data ? getCharacterStatusByStreak(data.character.streak) : null;
-  const characterImage = data
-    ? getCharacterImagePath(data.character, characterStatus ?? CHARACTER_STATUS.NORMAL)
-    : null;
-
-  const calendarData = grassData ? transformGrassData(grassData.grass) : [];
-  const activeSession = validSessions?.[0] ?? null;
+  //로딩 처리를 위한 쿼리 결합
+  const isLoading = userQuery.isLoading || grassQuery.isLoading || validSessionsQuery.isLoading;
+  const error = userQuery.error ?? grassQuery.error ?? validSessionsQuery.error;
+  const hasAllData =
+    userQuery.data !== undefined &&
+    grassQuery.data !== undefined &&
+    validSessionsQuery.data !== undefined;
 
   return (
-    <div className="flex flex-col gap-6 p-6 pb-20">
-      <UserStatusCardSection />
-      <section className="flex flex-col items-center justify-center px-5">
-        {characterImage && (
-          <Image
-            src={characterImage}
-            alt={APP_MAIN_MESSAGES.CHARACTER_IMAGE_ALT}
-            width={400}
-            height={300}
-          />
-        )}
-        <p className="text-xl font-semibold">{data?.character.name}</p>
-      </section>
-      <section className="bg-bg-muted rounded-lg p-3">
-        {calendarData.length > 0 && <ActivityCalendar data={calendarData} />}
-      </section>
-      {activeSession && (
-        <LinkCard
-          href={buildStretchSessionPath(activeSession.sessionId)}
-          headerHeight="sm"
-          className="hover:border-border-strong hover:bg-bg-subtle transition-colors"
-          footer={
-            <span className="text-brand-700 text-sm font-semibold">
-              {APP_MAIN_MESSAGES.ACTIVE_SESSION.CTA}
-            </span>
-          }
-        >
-          <div className="flex flex-col gap-1">
-            <span className="text-text text-lg font-semibold">
-              {APP_MAIN_MESSAGES.ACTIVE_SESSION.TITLE}
-            </span>
-            <span className="text-text-muted text-sm">
-              {APP_MAIN_MESSAGES.ACTIVE_SESSION.DESCRIPTION}
-            </span>
-          </div>
-        </LinkCard>
-      )}
-      <section className="flex gap-3">
-        {APP_MAIN_ACTION_CARDS.map(({ key, href, title, image, description }) => (
-          <div key={key} className="flex-1">
-            <LinkCard
-              href={href}
-              headerHeight="md"
-              className="hover:border-border-strong hover:bg-bg-subtle transition-colors"
-              header={
-                <div className="flex h-full w-full items-center justify-center">
-                  <Image src={image} alt={title} width={48} height={48} />
+    <LoadableBoundary
+      isLoading={isLoading}
+      error={error}
+      data={
+        hasAllData
+          ? {
+              user: userQuery.data,
+              grass: grassQuery.data,
+              validSessions: validSessionsQuery.data,
+            }
+          : undefined
+      }
+      renderLoading={() => <AppMainPageSkeleton />}
+      renderError={() => <ErrorScreen variant="unexpected" />}
+    >
+      {({ user, grass, validSessions }) => {
+        const characterStatus = getCharacterStatusByStreak(user.character.streak);
+        const characterImage = getCharacterImagePath(
+          user.character,
+          characterStatus ?? CHARACTER_STATUS.NORMAL,
+        );
+        const calendarData = transformGrassData(grass.grass);
+        const activeSession = validSessions?.[0] ?? null;
+
+        return (
+          <div className="flex flex-col gap-6 p-6 pb-20">
+            <UserStatusCardSection />
+            <section className="flex flex-col items-center justify-center px-5">
+              <Image
+                src={characterImage}
+                alt={APP_MAIN_MESSAGES.CHARACTER_IMAGE_ALT}
+                width={400}
+                height={300}
+              />
+              <p className="text-xl font-semibold">{user.character.name}</p>
+            </section>
+            <section className="bg-bg-muted rounded-lg p-3">
+              {calendarData.length > 0 && <ActivityCalendar data={calendarData} />}
+            </section>
+            {activeSession && (
+              <LinkCard
+                href={buildStretchSessionPath(activeSession.sessionId)}
+                headerHeight="sm"
+                className="hover:border-border-strong hover:bg-bg-subtle transition-colors"
+                footer={
+                  <span className="text-brand-700 text-sm font-semibold">
+                    {APP_MAIN_MESSAGES.ACTIVE_SESSION.CTA}
+                  </span>
+                }
+              >
+                <div className="flex flex-col gap-1">
+                  <span className="text-text text-lg font-semibold">
+                    {APP_MAIN_MESSAGES.ACTIVE_SESSION.TITLE}
+                  </span>
+                  <span className="text-text-muted text-sm">
+                    {APP_MAIN_MESSAGES.ACTIVE_SESSION.DESCRIPTION}
+                  </span>
                 </div>
-              }
-              footer={
-                <div>
-                  <span className="text-sm">{description}</span>
+              </LinkCard>
+            )}
+            <section className="flex gap-3">
+              {APP_MAIN_ACTION_CARDS.map(({ key, href, title, image, description }) => (
+                <div key={key} className="flex-1">
+                  <LinkCard
+                    href={href}
+                    headerHeight="md"
+                    className="hover:border-border-strong hover:bg-bg-subtle transition-colors"
+                    header={
+                      <div className="flex h-full w-full items-center justify-center">
+                        <Image src={image} alt={title} width={48} height={48} />
+                      </div>
+                    }
+                    footer={
+                      <div>
+                        <span className="text-sm">{description}</span>
+                      </div>
+                    }
+                  >
+                    <div className="text-text flex items-center justify-between text-center text-lg font-semibold">
+                      {title}
+                      <ChevronRight className="ml-2" />
+                    </div>
+                  </LinkCard>
                 </div>
-              }
-            >
-              <div className="text-text flex items-center justify-between text-center text-lg font-semibold">
-                {title}
-                <ChevronRight className="ml-2" />
-              </div>
-            </LinkCard>
+              ))}
+            </section>
           </div>
-        ))}
-      </section>
-    </div>
+        );
+      }}
+    </LoadableBoundary>
   );
 }

--- a/apps/web/src/pages/app-notifications/ui/AppNotificationsPage.skeleton.tsx
+++ b/apps/web/src/pages/app-notifications/ui/AppNotificationsPage.skeleton.tsx
@@ -1,0 +1,11 @@
+import { NotificationListSkeleton } from '@/src/features/notifications/ui/NotificationList.skeleton';
+
+export function AppNotificationsPageSkeleton() {
+  return (
+    <div className="flex flex-col">
+      <div className="flex flex-1 flex-col gap-4 px-4 pt-4 pb-6">
+        <NotificationListSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/app-notifications/ui/AppNotificationsPage.tsx
+++ b/apps/web/src/pages/app-notifications/ui/AppNotificationsPage.tsx
@@ -15,7 +15,7 @@ export function AppNotificationsPage() {
   const queryClient = useQueryClient();
   const hasMarkedReadRef = useRef(false);
 
-  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+  const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useNotificationsInfiniteQuery(NOTIFICATIONS_CONFIG.PAGE_LIMIT);
 
   const notifications = useMemo(
@@ -56,6 +56,7 @@ export function AppNotificationsPage() {
         <NotificationList
           items={notifications}
           isLoading={isLoading}
+          error={error}
           isFetchingNextPage={isFetchingNextPage}
           hasNextPage={Boolean(hasNextPage)}
           onFetchNext={() => void fetchNextPage()}

--- a/apps/web/src/pages/app-plan/config/messages.ts
+++ b/apps/web/src/pages/app-plan/config/messages.ts
@@ -2,4 +2,5 @@ export const APP_PLAN_PAGE_MESSAGES = {
   HEADER: {
     TITLE: 'AI 추천 루틴',
   },
+  EMPTY: '표시할 루틴이 없습니다.',
 } as const;

--- a/apps/web/src/pages/app-plan/ui/AppPlanPage.skeleton.tsx
+++ b/apps/web/src/pages/app-plan/ui/AppPlanPage.skeleton.tsx
@@ -1,0 +1,25 @@
+import { Shimmer } from '@repo/ui/shimmer';
+import { Skeleton } from '@repo/ui/skeleton';
+import { SkeletonCard } from '@repo/ui/skeleton-card';
+import { SkeletonText } from '@repo/ui/skeleton-text';
+
+const SKELETON_CARD_COUNT = 3;
+
+export function AppPlanPageSkeleton() {
+  return (
+    <Shimmer>
+      <div className="flex min-h-screen flex-col gap-6 px-5 pb-6">
+        <div className="flex items-center justify-between pt-4">
+          <SkeletonText lines={1} widths={['40%']} />
+          <Skeleton className="h-8 w-20 rounded-md" />
+        </div>
+
+        <section className="flex flex-col gap-4">
+          {Array.from({ length: SKELETON_CARD_COUNT }).map((_, index) => (
+            <SkeletonCard key={`plan-card-${index}`} padding="md" className="h-40" />
+          ))}
+        </section>
+      </div>
+    </Shimmer>
+  );
+}

--- a/apps/web/src/pages/app-plan/ui/AppPlanPage.tsx
+++ b/apps/web/src/pages/app-plan/ui/AppPlanPage.tsx
@@ -3,41 +3,51 @@ import { useRouter } from 'next/router';
 
 import { ROUTINE_PLAN_MESSAGES, useRoutineQuery } from '@/src/features/routine-plan';
 import { ROUTES } from '@/src/shared/routes/routes';
+import { LoadableBoundary } from '@/src/shared/ui/boundary';
+import { ErrorScreen } from '@/src/shared/ui/error-screen';
 
 import { APP_PLAN_PAGE_MESSAGES } from '../config/messages';
+import { AppPlanPageSkeleton } from './AppPlanPage.skeleton';
 import { ExerciseCard } from './ExerciseCard';
 
 export function AppPlanPage() {
   const router = useRouter();
-  const { data, isLoading } = useRoutineQuery();
+  const { data, isLoading, error } = useRoutineQuery();
 
   const handleEditSurvey = () => {
     void router.push(ROUTES.SURVEY_EDIT);
   };
 
-  //TODO: 공통 로딩 페이지 연결
-  if (isLoading) {
-    return <>로딩중</>;
-  }
-
-  if (!data || data.exercises.length === 0) {
-    return <>데이터 없음</>;
-  }
-
   return (
-    <div className="flex min-h-screen flex-col gap-6 px-5 pb-6">
-      <div className="flex items-center justify-between pt-4">
-        <h1 className="text-text text-xl font-bold">{APP_PLAN_PAGE_MESSAGES.HEADER.TITLE}</h1>
-        <Button variant="outline" size="sm" onClick={handleEditSurvey}>
-          {ROUTINE_PLAN_MESSAGES.SURVEY_EDIT.BUTTON}
-        </Button>
-      </div>
+    <LoadableBoundary
+      isLoading={isLoading}
+      error={error}
+      data={data}
+      isEmpty={Boolean(data && data.exercises.length === 0)}
+      renderLoading={() => <AppPlanPageSkeleton />}
+      renderError={() => <ErrorScreen variant="unexpected" />}
+      renderEmpty={() => (
+        <div className="text-text-muted flex min-h-screen items-center justify-center px-5 text-sm">
+          {APP_PLAN_PAGE_MESSAGES.EMPTY}
+        </div>
+      )}
+    >
+      {(routine) => (
+        <div className="flex min-h-screen flex-col gap-6 px-5 pb-6">
+          <div className="flex items-center justify-between pt-4">
+            <h1 className="text-text text-xl font-bold">{APP_PLAN_PAGE_MESSAGES.HEADER.TITLE}</h1>
+            <Button variant="outline" size="sm" onClick={handleEditSurvey}>
+              {ROUTINE_PLAN_MESSAGES.SURVEY_EDIT.BUTTON}
+            </Button>
+          </div>
 
-      <section className="flex flex-col gap-4">
-        {data.exercises.map((exercise) => (
-          <ExerciseCard key={exercise.exerciseId} exercise={exercise} />
-        ))}
-      </section>
-    </div>
+          <section className="flex flex-col gap-4">
+            {routine.exercises.map((exercise) => (
+              <ExerciseCard key={exercise.exerciseId} exercise={exercise} />
+            ))}
+          </section>
+        </div>
+      )}
+    </LoadableBoundary>
   );
 }

--- a/apps/web/src/shared/config/loading.ts
+++ b/apps/web/src/shared/config/loading.ts
@@ -1,0 +1,12 @@
+/**
+ * 전역 로딩 컨트롤러,스켈레톤,바운더리에서 사용
+ */
+export const LOADING_CONFIG = {
+  /** 로딩 UI 표시 전 기본 딜레이->짧은 작업 플리커 방지 */
+  DEFAULT_DELAY: 200,
+  /** 표시 시작 후 최소 유지 시간(플리커 방지) */
+  MIN_DURATION: 200,
+  /** 상단 프로그레스 바 px */
+  TOP_PROGRESS_HEIGHT: 3,
+  Z_INDEX: 9999,
+} as const;

--- a/apps/web/src/shared/lib/loading/index.ts
+++ b/apps/web/src/shared/lib/loading/index.ts
@@ -1,0 +1,1 @@
+export { useDelayedValue } from './useDelayedValue';

--- a/apps/web/src/shared/lib/loading/useDelayedValue.ts
+++ b/apps/web/src/shared/lib/loading/useDelayedValue.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * 로딩 상태 표시를 지연해 플리커를 방지를 위함
+ * @param value - 지연할 값
+ * @param delayMs - true 전환을 지연할 시간
+ * @returns 지연된 boolean
+ */
+export function useDelayedValue(value: boolean, delayMs: number): boolean {
+  const [delayedValue, setDelayedValue] = useState(false);
+
+  useEffect(() => {
+    if (value) {
+      //true 전환 지연
+      const timerId = setTimeout(() => {
+        setDelayedValue(true);
+      }, delayMs);
+
+      return () => {
+        clearTimeout(timerId);
+      };
+    }
+
+    //false 전환 시 숨김
+    setDelayedValue(false);
+    return undefined;
+  }, [value, delayMs]);
+
+  return delayedValue;
+}

--- a/apps/web/src/shared/model/loading/GlobalLoadingController.ts
+++ b/apps/web/src/shared/model/loading/GlobalLoadingController.ts
@@ -1,0 +1,155 @@
+import { create } from 'zustand';
+
+import { LOADING_CONFIG } from '@/src/shared/config/loading';
+
+interface LoadingState {
+  /** 로딩 키별 ref-count 맵 */
+  loadingKeys: Map<string, number>;
+  /** 지연 표시용 타이머 id */
+  showTimers: Map<string, NodeJS.Timeout>;
+  /** 최소 유지 시간용 타이머 id */
+  minDurationTimers: Map<string, NodeJS.Timeout>;
+  /** 로딩 ui 노출 여부 */
+  isVisible: boolean;
+}
+
+interface LoadingStore extends LoadingState {
+  _startLoading: (key: string) => void;
+  _endLoading: (key: string) => void;
+  _setVisible: (visible: boolean) => void;
+}
+
+/**
+ * 전역 로딩 상태
+ * ref-count 기반 로딩 키를 지연/최소 유지 시간과 함께 관리
+ */
+//TODO: 추후 비동기 작업 상태와 충돌하지 않는지 확인
+const useLoadingStore = create<LoadingStore>((set, get) => ({
+  loadingKeys: new Map(),
+  showTimers: new Map(),
+  minDurationTimers: new Map(),
+  isVisible: false,
+
+  _startLoading: (key: string) => {
+    const state = get();
+    const newKeys = new Map(state.loadingKeys);
+    const currentCount = newKeys.get(key) ?? 0;
+    newKeys.set(key, currentCount + 1);
+
+    //최초 참조일 때만 딜레이 타이머 시작
+    if (currentCount === 0) {
+      const newShowTimers = new Map(state.showTimers);
+      const timerId = setTimeout(() => {
+        set({ isVisible: true });
+        get().showTimers.delete(key);
+      }, LOADING_CONFIG.DEFAULT_DELAY);
+      newShowTimers.set(key, timerId);
+      set({ showTimers: newShowTimers });
+    }
+
+    set({ loadingKeys: newKeys });
+  },
+
+  _endLoading: (key: string) => {
+    const state = get();
+    const newKeys = new Map(state.loadingKeys);
+    const currentCount = newKeys.get(key) ?? 0;
+
+    if (currentCount <= 0) {
+      return;
+    }
+
+    const newCount = currentCount - 1;
+
+    if (newCount === 0) {
+      newKeys.delete(key);
+
+      //대기 중인 표시 타이머가 있으면 정리
+      const showTimer = state.showTimers.get(key);
+      if (showTimer) {
+        clearTimeout(showTimer);
+        const newShowTimers = new Map(state.showTimers);
+        newShowTimers.delete(key);
+        set({ showTimers: newShowTimers });
+      }
+
+      //표시 중이면 최소 유지 시간 보장
+      if (state.isVisible) {
+        const newMinTimers = new Map(state.minDurationTimers);
+        const timerId = setTimeout(() => {
+          //모든 로딩 키가 해제됐는지 확인
+          if (get().loadingKeys.size === 0) {
+            set({ isVisible: false });
+          }
+          get().minDurationTimers.delete(key);
+        }, LOADING_CONFIG.MIN_DURATION);
+        newMinTimers.set(key, timerId);
+        set({ minDurationTimers: newMinTimers });
+      } else {
+        //아직 보이지 않았다면 즉시 숨김 처리 여부 확인
+        if (newKeys.size === 0) {
+          set({ isVisible: false });
+        }
+      }
+    } else {
+      newKeys.set(key, newCount);
+    }
+
+    set({ loadingKeys: newKeys });
+  },
+
+  _setVisible: (visible: boolean) => {
+    set({ isVisible: visible });
+  },
+}));
+
+/**
+ * 전역 로딩 컨트롤러 싱글톤
+ * ref-count 및 타이밍 정책으로 로딩 상태를 관리
+ */
+const _GlobalLoadingController = () => ({
+  /**
+   * 특정 키의 로딩 시작
+   * 여러 번 호출되면 ref-count 증가
+   */
+  start(key: string): void {
+    useLoadingStore.getState()._startLoading(key);
+  },
+
+  /**
+   * 특정 키의 로딩 종료
+   * ref-count 감소, 0이 되면 숨김
+   */
+  end(key: string): void {
+    useLoadingStore.getState()._endLoading(key);
+  },
+
+  /**
+   * promise 실행 전후로 로딩 상태를 감싸기
+   * 시작 종료를 자동 처리
+   */
+  async withLoading<T>(key: string, promise: Promise<T>): Promise<T> {
+    try {
+      this.start(key);
+      return await promise;
+    } finally {
+      this.end(key);
+    }
+  },
+
+  /**
+   * 현재 로딩 상태 조회
+   */
+  _getState(): LoadingState {
+    const state = useLoadingStore.getState();
+    return {
+      loadingKeys: state.loadingKeys,
+      showTimers: state.showTimers,
+      minDurationTimers: state.minDurationTimers,
+      isVisible: state.isVisible,
+    };
+  },
+});
+
+export const GlobalLoadingController = _GlobalLoadingController();
+export { useLoadingStore };

--- a/apps/web/src/shared/model/loading/index.ts
+++ b/apps/web/src/shared/model/loading/index.ts
@@ -1,0 +1,3 @@
+export { GlobalLoadingController } from './GlobalLoadingController';
+export { useGlobalLoadingState } from './useGlobalLoadingState';
+export { useRouteLoading } from './useRouteLoading';

--- a/apps/web/src/shared/model/loading/useGlobalLoadingState.ts
+++ b/apps/web/src/shared/model/loading/useGlobalLoadingState.ts
@@ -1,0 +1,10 @@
+/**
+ * 전역 로딩 노출 상태 조회
+ * 로딩 상태에 반응해야 하는 컴포넌트에서 사용
+ */
+import { useLoadingStore } from './GlobalLoadingController';
+
+export function useGlobalLoadingState(): { isVisible: boolean } {
+  const isVisible = useLoadingStore((state) => state.isVisible);
+  return { isVisible };
+}

--- a/apps/web/src/shared/model/loading/useRouteLoading.ts
+++ b/apps/web/src/shared/model/loading/useRouteLoading.ts
@@ -1,0 +1,38 @@
+/**
+ * 라우터 이벤트를 전역 로딩 컨트롤러와 연결 -> 상단 프로그레스바 보여줌
+ * _app.tsx에서 호출
+ */
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+import { GlobalLoadingController } from './GlobalLoadingController';
+
+const ROUTE_LOADING_KEY = 'route-transition';
+
+export function useRouteLoading(): void {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleRouteChangeStart = () => {
+      GlobalLoadingController.start(ROUTE_LOADING_KEY);
+    };
+
+    const handleRouteChangeComplete = () => {
+      GlobalLoadingController.end(ROUTE_LOADING_KEY);
+    };
+
+    const handleRouteChangeError = () => {
+      GlobalLoadingController.end(ROUTE_LOADING_KEY);
+    };
+
+    router.events.on('routeChangeStart', handleRouteChangeStart);
+    router.events.on('routeChangeComplete', handleRouteChangeComplete);
+    router.events.on('routeChangeError', handleRouteChangeError);
+
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChangeStart);
+      router.events.off('routeChangeComplete', handleRouteChangeComplete);
+      router.events.off('routeChangeError', handleRouteChangeError);
+    };
+  }, [router]);
+}

--- a/apps/web/src/shared/ui/boundary/LoadableBoundary.tsx
+++ b/apps/web/src/shared/ui/boundary/LoadableBoundary.tsx
@@ -1,0 +1,95 @@
+import type { ReactNode } from 'react';
+
+import { LOADING_CONFIG } from '@/src/shared/config/loading';
+import { useDelayedValue } from '@/src/shared/lib/loading';
+
+export interface LoadableBoundaryProps<TData> {
+  isLoading: boolean; //초기데이터 로딩 여부
+  isFetching?: boolean; //리페치 중인지
+  error: Error | null | unknown; //에러 객체
+  data: TData | undefined; //데이터
+  isEmpty?: boolean; //빈 상태 여부
+
+  renderLoading: () => ReactNode; //로딩 상태 렌더 함수
+  renderError: (error: Error | unknown) => ReactNode; //에러 상태 렌더 함수
+  renderWarning?: (error: Error | unknown) => ReactNode; //경고 상태 렌더 함수
+  renderEmpty?: () => ReactNode; //빈 상태 렌더 함수
+  children: (data: TData) => ReactNode; //성공 상태 렌더 함수
+
+  skipDelay?: boolean; //로딩 딜레이 스킵?
+}
+
+/**
+ * 로딩/에러/빈 상태 처리하는 공용 바운더리 컴포넌트
+ * 딜레이 기반 스켈레톤 표시로 플리커 방지
+ * keepPreviousData 지원 -> 리페치 실패 시 기존 데이터 유지
+ */
+export function LoadableBoundary<TData>({
+  isLoading,
+  isFetching = false,
+  error,
+  data,
+  isEmpty = false,
+  renderLoading,
+  renderError,
+  renderWarning,
+  renderEmpty,
+  children,
+  skipDelay = false,
+}: LoadableBoundaryProps<TData>) {
+  const shouldShowLoading = useDelayedValue(
+    isLoading,
+    skipDelay ? 0 : LOADING_CONFIG.DEFAULT_DELAY,
+  );
+  const hasData = data !== undefined;
+  const hasError = Boolean(error);
+  const shouldRenderWarning = hasError && hasData && Boolean(renderWarning);
+
+  //처리 우선순위: 에러 → 로딩 → 빈 상태 → 성공
+
+  //데이터가 없을 때만 블로킹 에러 표시
+  if (hasError && !hasData) {
+    return <>{renderError(error)}</>;
+  }
+
+  //초기 로딩 시 스켈레톤 표시(딜레이 적용)
+  if (isLoading && shouldShowLoading) {
+    return (
+      <div aria-busy="true" aria-label="Loading content">
+        {renderLoading()}
+      </div>
+    );
+  }
+
+  //리페치 중 & 기존 데이터 있음 - 기존 데이터 유지(스켈레톤 없음)
+  if (isFetching && hasData && !shouldRenderWarning) {
+    return <>{children(data)}</>;
+  }
+
+  //데이터가 비었으면 빈 상태 표시
+  if (isEmpty && renderEmpty) {
+    return (
+      <>
+        {shouldRenderWarning ? renderWarning?.(error) : null}
+        {renderEmpty()}
+      </>
+    );
+  }
+
+  //데이터 있으면 성공 상태
+  if (hasData) {
+    return (
+      <>
+        {shouldRenderWarning ? renderWarning?.(error) : null}
+        {children(data)}
+      </>
+    );
+  }
+
+  //에러 표시
+  if (hasError) {
+    return <>{renderError(error)}</>;
+  }
+
+  return null;
+}

--- a/apps/web/src/shared/ui/boundary/index.ts
+++ b/apps/web/src/shared/ui/boundary/index.ts
@@ -1,0 +1,5 @@
+/**
+ * 바운더리 컴포넌트 Public API
+ */
+export type { LoadableBoundaryProps } from './LoadableBoundary';
+export { LoadableBoundary } from './LoadableBoundary';

--- a/apps/web/src/shared/ui/loading/GlobalLoadingOverlay.tsx
+++ b/apps/web/src/shared/ui/loading/GlobalLoadingOverlay.tsx
@@ -1,0 +1,25 @@
+/**
+ * 전역 로딩이 활성화되면 TopProgressBar를 표시 (포탈 기반)
+ * _app.tsx에서 최상위에
+ */
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { useGlobalLoadingState } from '@/src/shared/model/loading';
+
+import { TopProgressBar } from './TopProgressBar';
+
+export function GlobalLoadingOverlay() {
+  const { isVisible } = useGlobalLoadingState();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted || !isVisible) {
+    return null;
+  }
+
+  return createPortal(<TopProgressBar />, document.body);
+}

--- a/apps/web/src/shared/ui/loading/TopProgressBar.tsx
+++ b/apps/web/src/shared/ui/loading/TopProgressBar.tsx
@@ -1,0 +1,14 @@
+import { LOADING_CONFIG } from '@/src/shared/config/loading';
+
+export function TopProgressBar() {
+  return (
+    <div
+      role="progressbar"
+      aria-label="Page loading"
+      className="fixed top-0 right-0 left-0 overflow-hidden"
+      style={{ height: `${LOADING_CONFIG.TOP_PROGRESS_HEIGHT}px`, zIndex: LOADING_CONFIG.Z_INDEX }}
+    >
+      <div className="animate-progress-indeterminate bg-brand-600 h-full w-full" />
+    </div>
+  );
+}

--- a/apps/web/src/shared/ui/loading/index.ts
+++ b/apps/web/src/shared/ui/loading/index.ts
@@ -1,0 +1,2 @@
+export { GlobalLoadingOverlay } from './GlobalLoadingOverlay';
+export { TopProgressBar } from './TopProgressBar';

--- a/apps/web/src/widgets/layout/main-header/ui/MainHeaderMenu.tsx
+++ b/apps/web/src/widgets/layout/main-header/ui/MainHeaderMenu.tsx
@@ -83,7 +83,7 @@ export function MainHeaderMenu() {
                 {MAIN_HEADER_MESSAGES.LOGOUT_CANCEL}
               </Button>
             </ConfirmDialogClose>
-            <Button size="sm" onClick={handleLogoutConfirm} disabled={isLogoutPending}>
+            <Button size="sm" onClick={handleLogoutConfirm} isLoading={isLogoutPending}>
               {MAIN_HEADER_MESSAGES.LOGOUT_CONFIRM}
             </Button>
           </ConfirmDialogFooter>

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -108,6 +108,24 @@ body {
   }
 }
 
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes progress-indeterminate {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
 .animate-result-fade {
   animation: result-fade-up 650ms ease-out both;
 }
@@ -118,6 +136,14 @@ body {
 
 .animate-result-pulse {
   animation: result-pulse 1.2s ease-in-out 2;
+}
+
+.animate-shimmer {
+  animation: shimmer 2s infinite;
+}
+
+.animate-progress-indeterminate {
+  animation: progress-indeterminate 1.5s ease-in-out infinite;
 }
 
 @keyframes fade-in {

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -1,10 +1,12 @@
-import { Slot } from 'radix-ui';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { cn } from './lib/utils';
 import { ElementType } from 'react';
+import { Slot } from 'radix-ui';
+
+import { Spinner } from './spinner';
+import { cn } from './lib/utils';
 
 const buttonVariants = cva(
-  /* Base styles */
+  /* 기본 스타일 */
   [
     'inline-flex items-center justify-center gap-2',
     'rounded-lg',
@@ -78,6 +80,7 @@ const buttonVariants = cva(
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  isLoading?: boolean;
 }
 
 export function Button({
@@ -86,12 +89,27 @@ export function Button({
   size,
   fullWidth,
   asChild = false,
+  isLoading = false,
+  disabled,
+  children,
   ...props
 }: ButtonProps) {
   const Comp = (asChild ? Slot : 'button') as ElementType;
+  const resolvedSize = size ?? 'md';
+  const spinnerSize = resolvedSize === 'lg' ? 'md' : 'sm';
+  const isDisabled = Boolean(disabled || isLoading);
 
   return (
-    <Comp className={cn(buttonVariants({ variant, size, fullWidth, className }))} {...props} />
+    <Comp
+      className={cn(buttonVariants({ variant, size: resolvedSize, fullWidth, className }))}
+      aria-busy={isLoading || undefined}
+      aria-disabled={isDisabled || undefined}
+      disabled={isDisabled}
+      {...props}
+    >
+      {isLoading && <Spinner size={spinnerSize} className="shrink-0" />}
+      {children}
+    </Comp>
   );
 }
 

--- a/packages/ui/src/shimmer.tsx
+++ b/packages/ui/src/shimmer.tsx
@@ -1,0 +1,17 @@
+import type React from 'react';
+import { cn } from './lib/utils';
+
+export interface ShimmerProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+export function Shimmer({ className, children, ...props }: ShimmerProps) {
+  return (
+    <div className={cn('relative overflow-hidden', className)} {...props}>
+      {children}
+      <div className="animate-shimmer absolute inset-0 -translate-x-full bg-linear-to-r from-transparent via-white/10 to-transparent" />
+    </div>
+  );
+}
+
+Shimmer.displayName = 'Shimmer';

--- a/packages/ui/src/skeleton-avatar.tsx
+++ b/packages/ui/src/skeleton-avatar.tsx
@@ -1,0 +1,32 @@
+import type React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Skeleton } from './skeleton';
+import { cn } from './lib/utils';
+
+const skeletonAvatarVariants = cva('', {
+  variants: {
+    size: {
+      sm: 'h-8 w-8',
+      md: 'h-12 w-12',
+      lg: 'h-16 w-16',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+});
+
+export interface SkeletonAvatarProps
+  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof skeletonAvatarVariants> {}
+
+export function SkeletonAvatar({ className, size, ...props }: SkeletonAvatarProps) {
+  return (
+    <Skeleton
+      variant="circle"
+      className={cn(skeletonAvatarVariants({ size }), className)}
+      {...props}
+    />
+  );
+}
+
+SkeletonAvatar.displayName = 'SkeletonAvatar';

--- a/packages/ui/src/skeleton-card.tsx
+++ b/packages/ui/src/skeleton-card.tsx
@@ -1,0 +1,35 @@
+import type React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Skeleton } from './skeleton';
+import { cn } from './lib/utils';
+
+const skeletonCardVariants = cva('rounded-lg', {
+  variants: {
+    padding: {
+      sm: 'p-3',
+      md: 'p-4',
+      lg: 'p-6',
+    },
+  },
+  defaultVariants: {
+    padding: 'md',
+  },
+});
+
+export interface SkeletonCardProps
+  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof skeletonCardVariants> {
+  height?: string;
+}
+
+export function SkeletonCard({ className, padding, height, style, ...props }: SkeletonCardProps) {
+  return (
+    <Skeleton
+      variant="rect"
+      className={cn(skeletonCardVariants({ padding }), className)}
+      style={{ height, ...style }}
+      {...props}
+    />
+  );
+}
+
+SkeletonCard.displayName = 'SkeletonCard';

--- a/packages/ui/src/skeleton-text.tsx
+++ b/packages/ui/src/skeleton-text.tsx
@@ -1,0 +1,28 @@
+import type React from 'react';
+import { Skeleton } from './skeleton';
+import { cn } from './lib/utils';
+
+const DEFAULT_WIDTHS = ['100%', '100%', '60%'];
+
+export interface SkeletonTextProps extends React.HTMLAttributes<HTMLDivElement> {
+  lines?: number; //표시 줄 수
+  widths?: string[]; //각줄 너비
+}
+
+export function SkeletonText({
+  className,
+  lines = 3,
+  widths = DEFAULT_WIDTHS,
+  ...props
+}: SkeletonTextProps) {
+  return (
+    <div className={cn('space-y-2', className)} {...props}>
+      {Array.from({ length: lines }).map((_, index) => {
+        const width = widths[index % widths.length];
+        return <Skeleton key={index} variant="text" className="h-4" style={{ width }} />;
+      })}
+    </div>
+  );
+}
+
+SkeletonText.displayName = 'SkeletonText';

--- a/packages/ui/src/skeleton.tsx
+++ b/packages/ui/src/skeleton.tsx
@@ -1,0 +1,26 @@
+import type React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from './lib/utils';
+
+const skeletonVariants = cva('animate-pulse bg-bg-subtle', {
+  variants: {
+    variant: {
+      rect: 'rounded-md',
+      circle: 'rounded-full',
+      text: 'rounded',
+    },
+  },
+  defaultVariants: {
+    variant: 'rect',
+  },
+});
+
+export interface SkeletonProps
+  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof skeletonVariants> {}
+
+export function Skeleton({ className, variant, ...props }: SkeletonProps) {
+  return <div className={cn(skeletonVariants({ variant }), className)} {...props} />;
+}
+
+Skeleton.displayName = 'Skeleton';


### PR DESCRIPTION
🔷 Github Issue ID

- 작업한 내용에 해당하는 Issue 링크

📌 작업 내용 및 특이사항

# 구현 사항 

### 1. 글로벌 로딩 컨트롤러 추가 `apps/web/src/shared/model/loading/` - for 라우트 로딩

목적 : 라우트 전환 / 여러 비동기 요청 겹치는 상황에 플리커를 줄이려고 함. 
그리고 그냥 모두 로딩 상태 보여주는 경우에는 로딩ui 를 보여주지 않는 것이 ux 적으로 좋다. 

zustand 사용해서 전역적으로 로딩 스테이트를 한번에 관리하고자 했다. 


**위치**: `apps/web/src/shared/model/loading/`

**파일**:
- `GlobalLoadingController.ts` - Zustand 기반 상태 관리
- `useGlobalLoadingState.ts` - 리액티브 상태 훅
- `useRouteLoading.ts` - Next.js 라우터 연동

zustand store 는 다음과 같이 구현되어 있다. 
- ref-count 도입 <- 이렇게 하는 이유는, 비동기 요청이 겹쳤을 때 먼저 끝난 요청이 로딩을 꺼버리는 버그가 있었기 때문이다. 따라서 남은 요청 수를 안정적으로 유지하기 위해 
해당 방식을 사용하고자 했다. 
**_=> tanstack query 의 `useIsFetching` 으로 전환을 예정하고 있다. _**
- Controller 를 정의해 싱글톤으로 관리하고, 키 로딩이 시작되거나(start) / 끝나거나(end) 를 관리할 수 있도록 했다. 

### 2. LoadableBoundary 컴포넌트 - for 데이터 로딩
로딩/에러/빈 상태 처리하는 공용 바운더리 컴포넌트

**위치**: `apps/web/src/shared/ui/boundary/LoadableBoundary.tsx`

**Props**:
```typescript
interface LoadableBoundaryProps<TData> {
  isLoading: boolean;           // 초기 로딩 상태
  isFetching?: boolean;         // 리페치 상태 (옵션)
  error: Error | null | unknown; // 에러 객체
  data: TData | undefined;      // 로드된 데이터
  isEmpty?: boolean;            // 빈 상태 체크
  renderLoading: () => ReactNode;  // 로딩 UI
  renderError: (error) => ReactNode; // 에러 UI
  renderEmpty?: () => ReactNode;   // 빈 상태 UI
  children: (data: TData) => ReactNode; // 성공 UI
  skipDelay?: boolean;          // 딜레이 스킵 (테스트용)
}
```

해당 부분은 여러 상태를 기반으로 하며, 이 우선순위가 다른 상태에 따라서 다른 ui 를 보여주도록 한다. 

처리 우선순위: [에러 → 로딩 → 빈 상태 → 성공] 이다.

ux 를 고려하여 예외를 두도록 한다. 
- 데이터가 이미 있는 상태에서 에러가 발생하면 **기존 데이터 유지 + 비차단 경고(renderWarning)** 로 처리하도록 한다. 이는 ux를 고려함에 따른다. 

### 3. 스켈레톤 프리미티브 컴포넌트 생성

팀 컨벤션 : 스켈레톤 ui 가 필요한 page 단위로 `{컴포넌트명}.skeleton` 을 활용하여 스켈레톤 페이지를 프리미티브 컴포넌트를 조합하여 생성해 사용하도록 한다. 

### 4. 라우트 로딩

**통합 위치**: `pages/_app.tsx`

`useRouteLoading.ts` 

**동작**:
- Next.js 라우터 이벤트를 감지할 수 있다. 
Next.js Pages Router는 내부적으로 라우팅 상태 변화를 이벤트로 발행한다!! 그리고 페이지 이동 과정에서 Next.js 가 시점마다 이벤트를 쏜다. 

시점: 
- `routeChangeStart` → 로딩 시작으로 간주 (새 URL 이동 시작 순간)
- `routeChangeComplete/Error` → 로딩 종료 (새 페이지로 라우팅 끝난 순가 / 이동 실패 시에)

### 5. 뮤테이션 로딩 - 버튼에 추가
프리미티브 컴포넌트 버튼에 isLoading prop 추가하여 로딩 시 로딩 스피너를 띄우고 enable 하게 만든다. 

📚 참고사항

- **_상태머신 기반으로 리팩토링 예정이다_**

Closes #
