### PR TITLE
fix: Debug accuracy

### DIFF
--- a/packages/stretching-accuracy/src/engine/create-accuracy-engine.ts
+++ b/packages/stretching-accuracy/src/engine/create-accuracy-engine.ts
@@ -310,7 +310,7 @@ function calculateAccuracy(
   reference: (Landmark2D | undefined)[],
   user: (Landmark2D | undefined)[],
   tolerance: number = 0.15,
-  zWeight: number = 0.3,
+  zWeight: number = 0.2,
 ): number {
   if (reference.length === 0 || reference.length !== user.length) {
     return 0;


### PR DESCRIPTION
### Github Issue ID
None

### 작업 내용
- DURATION 타입에서 `prevPhase='undefined'` 문자열 처리 버그 수정

### 특이사항
- 첫 호출 시 `prevPhase='undefined'`(문자열)가 truthy로 처리되어 else 블록 진입 → 즉시 end, 1.0 반환되던 문제
- TypeScript, Python 레퍼런스 코드 둘 다 수정
- z값 가중치 0.3 -> 0.2


### 참고사항
없음