### PR TITLE
fix: set minhealth to 100% for zero downtime deployment

### DIFF
--- a/.github/workflows/deploy-asg-rolling.yml
+++ b/.github/workflows/deploy-asg-rolling.yml
@@ -131,7 +131,7 @@ jobs:
           fi
           
           if [ "${{ inputs.environment }}" == "production" ]; then
-            MIN_HEALTHY=50
+            MIN_HEALTHY=100
           else
             MIN_HEALTHY=0
           fi
@@ -246,7 +246,7 @@ jobs:
             fi
           done
           echo "All instances are running the correct version."
-          
+
       - name: Set Launch Template Default Version
         if: success()
         run: |


### PR DESCRIPTION
🔷 Github Issue ID

- 작업한 내용에 해당하는 Issue 링크

📌 작업 내용 및 특이사항

- 안전한 무중단 배포를 위해 살아 있는 최소 인스턴스 비율을 100%로 설정

📚 참고사항

- PR 리뷰 과정에서 참고하면 좋을 내용들

Closes #
