### PR TITLE
fix: 좋아요 쿼리 오류 수정 (meta api 추가에 따른 수정)

### DIFF
--- a/apps/web/src/widgets/moments-detail-like/ui/MomentsDetailLikeSection.tsx
+++ b/apps/web/src/widgets/moments-detail-like/ui/MomentsDetailLikeSection.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
-import type { PostDetailDataType, PostLikeDataType } from '@/src/entities/post';
+import type { PostDetailDataType, PostLikeDataType, PostMetaDataType } from '@/src/entities/post';
 import { MOMENTS_DETAIL_QUERY_KEYS } from '@/src/features/moments-detail/config/query-keys';
 import { useLikePostMutation } from '@/src/features/moments-like';
 import { createLikeUpdater, createSingleOptimisticHandlers } from '@/src/shared/lib/react-query';
@@ -24,13 +24,13 @@ export function MomentsDetailLikeSection({
 
   const optimisticHandlers = createSingleOptimisticHandlers({
     queryClient,
-    queryKey: MOMENTS_DETAIL_QUERY_KEYS.detail(postId),
+    queryKey: MOMENTS_DETAIL_QUERY_KEYS.meta(postId),
     updater: createLikeUpdater<PostDetailDataType>(),
     invalidateOnSettled: false,
     onSuccessCallback: (responseData, variables) => {
       const serverData = responseData as PostLikeDataType;
-      const queryKey = MOMENTS_DETAIL_QUERY_KEYS.detail((variables as { postId: number }).postId);
-      queryClient.setQueryData<PostDetailDataType>(queryKey, (old) => {
+      const queryKey = MOMENTS_DETAIL_QUERY_KEYS.meta((variables as { postId: number }).postId);
+      queryClient.setQueryData<PostMetaDataType>(queryKey, (old) => {
         if (!old) return old;
         return {
           ...old,


### PR DESCRIPTION
🔷 Github Issue ID

- 작업한 내용에 해당하는 Issue 링크

📌 작업 내용 및 특이사항

- [배경] 좋아요 OptimisticUpdate 위해 detailPage queryKey 를 가지고 해당 데이터에 옵티미스틱 업데이트를 하고 있던 상황 
- [문제] meta api 가 추가되며 detail 을 meta 가 덮고 있는 상황 (...meta)
- [해결] detail -> meta 로 옵티미스틱 업데이트 대상을 변경

📚 참고사항

- PR 리뷰 과정에서 참고하면 좋을 내용들

Closes #
