### PR TITLE
fix(bottom-sheet): tbt 위해 바텀시트 늦게 띄우기, dynamic import 적용

### DIFF
--- a/apps/web/src/widgets/layout/authenticated-shell/ui/index.tsx
+++ b/apps/web/src/widgets/layout/authenticated-shell/ui/index.tsx
@@ -1,19 +1,34 @@
 import { useQueryClient } from '@tanstack/react-query';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import type { PropsWithChildren } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { useOnboardingStatusQuery } from '@/src/features/onboarding-status';
-import {
-  PushPermissionBottomSheet,
-  usePushPermissionSheet,
-} from '@/src/features/push-notifications';
+import { usePushPermissionSheet } from '@/src/features/push-notifications';
 import { isApiError } from '@/src/shared/api';
 import { HTTP_STATUS } from '@/src/shared/config/http-status';
 import { isIosUserAgent, isMobileUserAgent } from '@/src/shared/lib/device/user-agent';
 import { usePwaInstallState } from '@/src/shared/lib/pwa/usePwaInstallState';
 import { ROUTE_GROUPS, ROUTES } from '@/src/shared/routes';
-import { PwaInstallBottomSheet } from '@/src/widgets/pwa-install';
+
+const PushPermissionBottomSheet = dynamic(
+  () =>
+    import('@/src/features/push-notifications/ui/PushPermissionBottomSheet').then(
+      (mod) => mod.PushPermissionBottomSheet,
+    ),
+  { ssr: false },
+);
+
+const PwaInstallBottomSheet = dynamic(
+  () =>
+    import('@/src/widgets/pwa-install/ui/PwaInstallBottomSheet').then(
+      (mod) => mod.PwaInstallBottomSheet,
+    ),
+  { ssr: false },
+);
+
+const BOTTOM_SHEET_IDLE_TIMEOUT_MS = 1200;
 
 let hasShownPwaInstallSheet = false;
 
@@ -23,13 +38,14 @@ export function AuthenticatedShell({ children }: PropsWithChildren) {
   const [isMobile, setIsMobile] = useState(false);
   const [isIos, setIsIos] = useState(false);
   const [isPwaSheetOpen, setIsPwaSheetOpen] = useState(false);
+  const [shouldMountBottomSheets, setShouldMountBottomSheets] = useState(false);
   const pwaState = usePwaInstallState();
 
   const isAppRoute = useMemo(
     () => (ROUTE_GROUPS.APP as readonly string[]).includes(router.pathname),
     [router.pathname],
   );
-  const shouldAutoOpenPushPermissionSheet = isAppRoute && router.isReady;
+  const shouldAutoOpenPushPermissionSheet = shouldMountBottomSheets && isAppRoute && router.isReady;
   const pushPermissionSheet = usePushPermissionSheet({
     autoOpen: shouldAutoOpenPushPermissionSheet,
   });
@@ -93,7 +109,35 @@ export function AuthenticatedShell({ children }: PropsWithChildren) {
     setIsIos(isIosUserAgent(userAgent));
   }, []);
 
+  useEffect(() => {
+    if (!isAppRoute) {
+      setShouldMountBottomSheets(false);
+      return;
+    }
+
+    const mountBottomSheets = () => {
+      setShouldMountBottomSheets(true);
+    };
+
+    const requestIdleCallbackFn = window.requestIdleCallback;
+    if (typeof requestIdleCallbackFn === 'function') {
+      const idleCallbackId = requestIdleCallbackFn(mountBottomSheets, {
+        timeout: BOTTOM_SHEET_IDLE_TIMEOUT_MS,
+      });
+      return () => {
+        window.cancelIdleCallback?.(idleCallbackId);
+      };
+    }
+
+    const timerId = window.setTimeout(mountBottomSheets, BOTTOM_SHEET_IDLE_TIMEOUT_MS);
+
+    return () => {
+      window.clearTimeout(timerId);
+    };
+  }, [isAppRoute]);
+
   const shouldShowPwaSheet =
+    shouldMountBottomSheets &&
     isAppRoute &&
     isMobile &&
     pwaState.isReady &&
@@ -112,7 +156,7 @@ export function AuthenticatedShell({ children }: PropsWithChildren) {
   return (
     <main className="h-full">
       {children}
-      {shouldRenderGlobalPushSheet && (
+      {shouldMountBottomSheets && shouldRenderGlobalPushSheet && (
         <PushPermissionBottomSheet
           open={pushPermissionSheet.open}
           onOpenChange={pushPermissionSheet.setOpen}
@@ -122,7 +166,7 @@ export function AuthenticatedShell({ children }: PropsWithChildren) {
           onRequestPermission={pushPermissionSheet.requestPermission}
         />
       )}
-      {isAppRoute && isMobile && (
+      {shouldMountBottomSheets && isAppRoute && isMobile && (
         <PwaInstallBottomSheet
           open={isPwaSheetOpen}
           onOpenChange={setIsPwaSheetOpen}


### PR DESCRIPTION
🔷 Github Issue ID

- 작업한 내용에 해당하는 Issue 링크

📌 작업 내용 및 특이사항

- tbt 를 위해 바텀시트를 늦게 띄움 (requestIdleCallback ,setTimeout)
- dynamic import 적용

📚 참고사항

- requestIdleCallback 을 safari 에서 지원하지 않기에 이 경우 setTimeout 으로 fallback


- 시도했던 부분: 
`AuthenticatedShell`에서 `usePushPermissionSheet`/`usePwaInstallState` 실행을 제거하고 신규 `DeferredBottomSheets` 동적 컴포넌트로 분리해, 초기 렌더에서 푸시/Firebase 체인이 실행되지 않도록 지연 로딩 구조로 리팩터링했다.


이전
<img width="2914" height="1884" alt="image" src="https://github.com/user-attachments/assets/340dbd40-bde9-470d-86f7-546f6f4ff47e" />


이후
<img width="2942" height="1936" alt="image" src="https://github.com/user-attachments/assets/24ea2757-b098-4a6b-93c3-685e0a64978c" />



그런데 그러니 오히려 lcp 가 늘었다. 
630 bundle 로 빠졌었고, image 다운로드와 함께 진행되는 것을 확인했다. 
=> image 는 lcp 요소이므로 오히려 cpu 점유때문에 지연을 주는 것이라고 추측하고 있다. 
위의 변경사항은 적용하지 않았다.

Closes #
