### PR TITLE
[#297] 웹폰트 최적화 다이나믹 서브셋 사용

### DIFF
--- a/apps/web/pages/_document.tsx
+++ b/apps/web/pages/_document.tsx
@@ -1,30 +1,22 @@
 import { Head, Html, Main, NextScript } from 'next/document';
 
-const PRELOAD_FONTS = [
-  '/fonts/Pretendard-Medium.woff2',
-  '/fonts/Pretendard-SemiBold.woff2',
-] as const;
-
 export default function Document() {
   return (
     <Html lang="ko">
       <Head>
+        <link rel="preconnect" href="https://cdn.jsdelivr.net" crossOrigin="anonymous" />
+        <link
+          rel="stylesheet"
+          as="style"
+          crossOrigin="anonymous"
+          href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css"
+        />
         <link rel="manifest" href="/manifest.json" />
         <meta name="theme-color" content="#ffffff" />
         <link rel="apple-touch-icon" sizes="180x180" href="/icons/logo-180.png" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="apple-mobile-web-app-title" content="Growing Developer" />
-        {PRELOAD_FONTS.map((font) => (
-          <link
-            key={font}
-            rel="preload"
-            href={font}
-            as="font"
-            type="font/woff2"
-            crossOrigin="anonymous"
-          />
-        ))}
       </Head>
       <body className="antialiased">
         <Main />

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -4,24 +4,11 @@
 /* packages/ui 안의 컴포넌트에서 쓰는 Tailwind class도 스캔 대상에 포함 */
 @source '../../../packages/ui/src/**/*.{js,jsx,ts,tsx}';
 
-@font-face {
-  font-family: 'Pretendard';
-  src: url('/fonts/Pretendard-Medium.woff2') format('woff2');
-  font-weight: 500;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Pretendard';
-  src: url('/fonts/Pretendard-SemiBold.woff2') format('woff2');
-  font-weight: 600;
-  font-style: normal;
-  font-display: swap;
-}
-
 :root {
-  --font-sans: 'Pretendard', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
+  --font-sans:
+    'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+    'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic',
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
   --footer-nav-height: 4rem; /* FooterNav 높이 */
 }
 
@@ -52,36 +39,6 @@ body {
 
 .animate-logo-float {
   animation: logo-float 4s ease-in-out infinite;
-}
-
-@keyframes splash-gradient {
-  0%,
-  100% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-}
-
-.animate-splash-bg {
-  background-size: 200% 200%;
-  animation: splash-gradient 14s ease-in-out infinite;
-}
-
-@keyframes splash-fade {
-  0% {
-    opacity: 0;
-    transform: translateY(8px) scale(0.98);
-  }
-  100% {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-.animate-splash-fade {
-  animation: splash-fade 800ms ease-out both;
 }
 
 @keyframes result-fade-up {
@@ -269,14 +226,6 @@ body {
 
 @media (prefers-reduced-motion: reduce) {
   .animate-logo-float {
-    animation: none;
-  }
-
-  .animate-splash-bg {
-    animation: none;
-  }
-
-  .animate-splash-fade {
     animation: none;
   }
 


### PR DESCRIPTION
🔷 Github Issue ID

- 작업한 내용에 해당하는 Issue 링크

📌 작업 내용 및 특이사항

## 변경 사항
- 로컬 Pretendard 웹폰트(`Pretendard-Medium.woff2`, `Pretendard-SemiBold.woff2`) 사용을 제거
- `_document.tsx`에서 공식 `Pretendard Variable dynamic subset` CDN stylesheet를 로드하도록 변경
- 전역 `font-family`를 `Pretendard Variable` 기반의 공식 권장 스택으로 정리
- 기존 로컬 full font preload 경로를 제거해 초기 네트워크 경쟁 리소스를 축소

## 배경
`/moments` 초기 로딩 성능을 확인하는 과정에서 Pretendard local full font가 주요 병목으로 드러났다.

실험상 전역에서 Pretendard를 제거했을 때 LCP가 약 `13s -> 7s`로 크게 개선되었고, 기존 구조에서는 아래와 같은 비용이 있었다.

- `Pretendard-Medium.woff2`: 약 `760KB`
- `Pretendard-SemiBold.woff2`: 약 `767KB`

즉, 초기 화면에서 실제로 필요한 텍스트 양과 무관하게 큰 폰트 파일 전체를 받아야 했고, 이 요청이 다른 초기 리소스와 대역폭 경쟁을 만들고 있었다.

공식 `Pretendard Variable dynamic subset`은 필요한 글자 범위만 분할 로드하는 방식이라, full local font 대비 초기 폰트 비용을 크게 줄일 수 있다.

## 기대 효과
- `/moments` 초기 진입 시 폰트 요청 비용 감소
- 초기 네트워크 경쟁 완화
- LCP/FCP 개선
- 여러 weight를 쓰더라도 static full font 여러 개를 받지 않도록 구조 단순화

📚 참고사항

- PR 리뷰 과정에서 참고하면 좋을 내용들

Closes #
