### PR TITLE
delete: 빌드 시간 위해 webgazer, mediapipe 테스트 페이지 삭제

### DIFF
--- a/apps/web/pages/test/debug-eye-stretching.tsx
+++ b/apps/web/pages/test/debug-eye-stretching.tsx
@@ -1,3 +1,0 @@
-import { DebugEyeStretchingPage } from '@/src/pages/test/debug-eye-stretching';
-
-export default DebugEyeStretchingPage;

--- a/apps/web/pages/test/debug-stretch-accuracy.tsx
+++ b/apps/web/pages/test/debug-stretch-accuracy.tsx
@@ -1,3 +1,0 @@
-import { DebugStretchAccuracyPage } from '@/src/pages/test/debug-stretch-accuracy';
-
-export default DebugStretchAccuracyPage;

--- a/apps/web/pages/test/debug-webgazer.tsx
+++ b/apps/web/pages/test/debug-webgazer.tsx
@@ -1,3 +1,0 @@
-import { DebugWebgazerPage } from '@/src/pages/test/debug-webgazer';
-
-export default DebugWebgazerPage;


### PR DESCRIPTION
🔷 Github Issue ID

- 작업한 내용에 해당하는 Issue 링크

📌 작업 내용 및 특이사항

디버그용 `pages/test/**` 엔트리가 프로덕션 `webpack` 빌드에 포함되면서 불필요한 타입체크/라우트 분석 비용이 발생하고 있어, 해당 페이지 엔트리를 제거했습니다. 
디버그 구현 본체는 `src/pages/test/**`에 그대로 두고 서비스 라우트에서만 제외했습니다. 

📚 참고사항

as-is
<img width="1622" height="1066" alt="image" src="https://github.com/user-attachments/assets/73d7746d-7a66-4080-b548-bef09b9606f5" />


to-be
<img width="730" height="512" alt="image" src="https://github.com/user-attachments/assets/04f0f606-2c3d-4b10-8198-e9a916563afa" />


Closes #
