### PR TITLE
[#377] repoui를 source export에서 prebuilddist 방식으로 전환

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -46,7 +46,6 @@ const svgComponentLoader = {
 const nextConfig: NextConfig = {
   output: 'standalone',
   reactStrictMode: true,
-  transpilePackages: ['@repo/ui'],
   turbopack: {
     rules: {
       '*.svg': {

--- a/packages/eye-stretching-session/lib/use-eye-stretching-session.ts
+++ b/packages/eye-stretching-session/lib/use-eye-stretching-session.ts
@@ -30,7 +30,7 @@ import {
   type EyeStretchingReference,
   type GazeFrame,
   type WebGazerInstance,
-} from '@repo/eye-stretching-session';
+} from '../src';
 
 import { EYE_SESSION_CONFIG } from '../config/constants';
 

--- a/packages/eye-stretching-session/package.json
+++ b/packages/eye-stretching-session/package.json
@@ -9,7 +9,10 @@
       "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     },
-    "./hook": "./lib/use-eye-stretching-session.ts"
+    "./hook": {
+      "types": "./dist/hook.d.mts",
+      "default": "./dist/hook.mjs"
+    }
   },
   "files": [
     "dist"

--- a/packages/eye-stretching-session/tsup.config.ts
+++ b/packages/eye-stretching-session/tsup.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: {
+    index: 'src/index.ts',
+    hook: 'lib/use-eye-stretching-session.ts',
+  },
   format: ['esm'],
   dts: true,
   sourcemap: true,
   clean: true,
+  splitting: false,
   target: 'es2022',
 });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,10 +3,23 @@
   "version": "0.0.0",
   "private": true,
   "exports": {
-    "./*": "./src/*.tsx",
-    "./lib/*": "./src/lib/*.ts"
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.mjs"
+    },
+    "./lib/*": {
+      "types": "./dist/lib/*.d.ts",
+      "default": "./dist/lib/*.mjs"
+    }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "pnpm run build:js && pnpm run build:types",
+    "build:js": "tsup",
+    "build:types": "tsc --emitDeclarationOnly --outDir dist --pretty false",
+    "dev": "tsup --watch",
     "lint": "eslint . --max-warnings 0",
     "generate:component": "turbo gen react-component",
     "check-types": "tsc --noEmit"
@@ -25,6 +38,7 @@
     "clsx": "^2.1.1",
     "eslint": "9.39.2",
     "tailwind-merge": "^3.4.0",
+    "tsup": "8.5.1",
     "typescript": "5.9.2"
   },
   "dependencies": {

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/*.tsx', 'src/lib/*.ts'],
+  format: ['esm'],
+  dts: false,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  target: 'es2022',
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,7 +67,7 @@ importers:
         version: link:../../packages/ui
       '@sentry/nextjs':
         specifier: ^10
-        version: 10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.1(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.2)
+        version: 10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.1(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.2)
       '@tanstack/react-query':
         specifier: ^5.90.19
         version: 5.90.19(react@19.2.3)
@@ -317,6 +317,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
+      tsup:
+        specifier: 8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.2)(yaml@2.8.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
@@ -381,7 +384,14 @@ importers:
     dependencies:
       '@sentry/nextjs':
         specifier: ^10.38.0
-        version: 10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.1(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.2)
+        version: 10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.1(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.2(esbuild@0.27.2))
+    devDependencies:
+      tsup:
+        specifier: 8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.2)(yaml@2.8.2)
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
 
   tooling/typescript-config: {}
 
@@ -9882,7 +9892,7 @@ snapshots:
 
   '@sentry/core@10.39.0': {}
 
-  '@sentry/nextjs@10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.1(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.2)':
+  '@sentry/nextjs@10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.1(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.2)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.39.0
@@ -9895,6 +9905,31 @@ snapshots:
       '@sentry/react': 10.39.0(react@19.2.3)
       '@sentry/vercel-edge': 10.39.0
       '@sentry/webpack-plugin': 4.9.1(webpack@5.105.2)
+      next: 16.1.1(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      rollup: 4.56.0
+      stacktrace-parser: 0.1.11
+    transitivePeerDependencies:
+      - '@opentelemetry/context-async-hooks'
+      - '@opentelemetry/core'
+      - '@opentelemetry/sdk-trace-base'
+      - encoding
+      - react
+      - supports-color
+      - webpack
+
+  '@sentry/nextjs@10.39.0(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(next@16.1.1(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.2(esbuild@0.27.2))':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.39.0
+      '@rollup/plugin-commonjs': 28.0.1(rollup@4.56.0)
+      '@sentry-internal/browser-utils': 10.39.0
+      '@sentry/bundler-plugin-core': 4.9.1
+      '@sentry/core': 10.39.0
+      '@sentry/node': 10.39.0
+      '@sentry/opentelemetry': 10.39.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)
+      '@sentry/react': 10.39.0(react@19.2.3)
+      '@sentry/vercel-edge': 10.39.0
+      '@sentry/webpack-plugin': 4.9.1(webpack@5.105.2(esbuild@0.27.2))
       next: 16.1.1(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       rollup: 4.56.0
       stacktrace-parser: 0.1.11
@@ -9984,6 +10019,16 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
       '@sentry/core': 10.39.0
+
+  '@sentry/webpack-plugin@4.9.1(webpack@5.105.2(esbuild@0.27.2))':
+    dependencies:
+      '@sentry/bundler-plugin-core': 4.9.1
+      unplugin: 1.0.1
+      uuid: 9.0.1
+      webpack: 5.105.2(esbuild@0.27.2)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@sentry/webpack-plugin@4.9.1(webpack@5.105.2)':
     dependencies:
@@ -13782,6 +13827,17 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  terser-webpack-plugin@5.3.16(esbuild@0.27.2)(webpack@5.105.2(esbuild@0.27.2)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      terser: 5.46.0
+      webpack: 5.105.2(esbuild@0.27.2)
+    optionalDependencies:
+      esbuild: 0.27.2
+
   terser-webpack-plugin@5.3.16(webpack@5.105.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -14140,6 +14196,38 @@ snapshots:
       schema-utils: 4.3.3
       tapable: 2.3.0
       terser-webpack-plugin: 5.3.16(webpack@5.105.2)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+
+  webpack@5.105.2(esbuild@0.27.2):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.15.0
+      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.19.0
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(esbuild@0.27.2)(webpack@5.105.2(esbuild@0.27.2))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:

--- a/tooling/sentry-config/package.json
+++ b/tooling/sentry-config/package.json
@@ -3,11 +3,27 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "main": "index.ts",
+  "main": "./dist/index.js",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "pnpm run build:js && pnpm run build:types",
+    "build:js": "tsup",
+    "build:types": "tsc --emitDeclarationOnly --outDir dist --pretty false",
+    "dev": "tsup --watch"
   },
   "peerDependencies": {
     "@sentry/nextjs": "^10.38.0"
+  },
+  "devDependencies": {
+    "tsup": "8.5.1",
+    "typescript": "5.9.2"
   }
 }

--- a/tooling/sentry-config/tsconfig.json
+++ b/tooling/sentry-config/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../typescript-config/base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "dist"
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tooling/sentry-config/tsup.config.ts
+++ b/tooling/sentry-config/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['index.ts'],
+  format: ['esm'],
+  dts: false,
+  sourcemap: false,
+  clean: true,
+  splitting: false,
+  target: 'es2022',
+});


### PR DESCRIPTION
🔷 Github Issue ID

- 작업한 내용에 해당하는 Issue 링크

📌 작업 내용 및 특이사항

## 배경

프로덕션 `webpack` 빌드 시간이 길어서 원인을 확인해보니, `apps/web`가 앱 코드만 빌드하는 것이 아니라
workspace package의 source TypeScript/TSX까지 함께 다시 컴파일하고 있었다. 

즉 앱이 라이브러리의 빌드 결과물을 소비하는 구조가 아닌
모노레포 package source를 앱 빌드에 직접 끌고 들어오는 구조였다. 

## 변경 사항

앱 빌드가 workspace source를 다시 컴파일하지 않도록 문제가 된 package들을 `dist` 기반 prebuild 구조로 전환

### 1. `@repo/ui`

- `src` 직접 export 제거
- `dist` 기반 export로 변경
- `tsup`으로 JS 산출물 생성
- `tsc --emitDeclarationOnly`로 타입 선언 생성

### 2. `@repo/eye-stretching-session`

- `./hook` export를 source file에서 `dist/hook.mjs`로 변경
- `tsup` multi-entry로 `index`, `hook` 동시 빌드
- hook 내부 self-import를 package import에서 상대 import로 정리

### 3. `@tooling/sentry-config`

- source export 제거
- `dist/index.js` 기반 export로 변경
- `tsup(JS) + tsc(d.ts)` 구조로 prebuild 가능하도록 정리

### 4. `apps/web`

- `next.config.ts`에서 `transpilePackages` 제거
- 앱은 이제 workspace package source가 아니라 prebuild 결과물만 소비


## 성과

빌드 책임 분리 + 증분 빌드/재빌드 최적화
`apps/web`는 `transpilePackages` 없이도 `webpack` 프로덕션 빌드를 통과



📚 참고사항

- PR 리뷰 과정에서 참고하면 좋을 내용들

Closes #
