### PR TITLE
[#379] fix: /moments 프로필 아바타에 OptimizedImage 적용 및 아바타 품질 최적화

### DIFF
--- a/apps/web/src/pages/moments-user-feed/ui/MomentsUserFeedPage.tsx
+++ b/apps/web/src/pages/moments-user-feed/ui/MomentsUserFeedPage.tsx
@@ -16,8 +16,10 @@ import {
   useUserProfileQuery,
 } from '@/src/features/user-profile';
 import { StreakImoji } from '@/src/shared/assets/StreakImoji';
+import { AVATAR_IMAGE_QUALITY, AVATAR_IMAGE_SIZES } from '@/src/shared/config/avatar';
 import { buildImageUrl } from '@/src/shared/lib/image';
 import { LoadableBoundary } from '@/src/shared/ui/boundary';
+import { OptimizedImage } from '@/src/shared/ui/optimized-image';
 import { MomentsList } from '@/src/widgets/moments-list';
 
 import { MOMENTS_USER_FEED_MESSAGES } from '../config/messages';
@@ -94,61 +96,77 @@ export function MomentsUserFeedPage({ authorId }: MomentsUserFeedPageProps) {
           renderLoading={() => null}
           renderError={() => null}
         >
-          {(user) => (
-            <div className="relative">
-              <UserStatusCard
-                avatarSrc={
-                  isEditing && previewUrl ? previewUrl : buildImageUrl(user.profile.imagePath)
-                }
-                avatarAlt={`${user.profile.nickname} 프로필 이미지`}
-                nickname={user.profile.nickname}
-                level={user.character.level}
-                streak={user.character.streak}
-                currentExp={user.character.exp}
-                totalExp={TOTAL_EXP}
-                streakIcon={<StreakImoji className="h-7 w-7" aria-hidden="true" />}
-                avatarBadge={
-                  isEditing ? (
-                    <ProfilePencilBadge
-                      onFileSelect={imageUpload.uploadFile}
-                      isLoading={imageUpload.isUploading}
-                      accept="image/jpeg,image/png,image/gif,image/webp,image/heic,image/heif"
-                    />
-                  ) : undefined
-                }
-                rightContent={
-                  isEditing ? (
-                    <ProfileNicknameEditForm
-                      authorId={authorId}
-                      initialNickname={user.profile.nickname}
-                      imageUpload={imageUpload}
-                      onDone={handleEditDone}
-                      onCancel={handleEditCancel}
-                    />
-                  ) : undefined
-                }
-                rightContentClassName="min-h-24"
-              />
-              <div className="absolute top-3 right-3 flex items-center gap-2">
-                {isMyProfile && !isEditing && (
-                  <>
-                    <Chip
-                      label={MOMENTS_USER_FEED_MESSAGES.MY_FEED_LABEL}
-                      variant="default"
-                      size="sm"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setIsEditing(true)}
-                      className="text-text-muted text-sm underline"
-                    >
-                      {MOMENTS_USER_FEED_MESSAGES.EDIT_BUTTON}
-                    </button>
-                  </>
-                )}
+          {(user) => {
+            const avatarImageSrc =
+              isEditing && previewUrl ? previewUrl : buildImageUrl(user.profile.imagePath);
+            const avatarAlt = `${user.profile.nickname} 프로필 이미지`;
+
+            return (
+              <div className="relative">
+                <UserStatusCard
+                  avatarSrc={avatarImageSrc}
+                  avatarAlt={avatarAlt}
+                  avatarImageSlot={
+                    avatarImageSrc ? (
+                      <OptimizedImage
+                        src={avatarImageSrc}
+                        alt={avatarAlt}
+                        fill
+                        className="object-cover"
+                        quality={AVATAR_IMAGE_QUALITY.MD}
+                        sizes={AVATAR_IMAGE_SIZES.MD}
+                      />
+                    ) : undefined
+                  }
+                  nickname={user.profile.nickname}
+                  level={user.character.level}
+                  streak={user.character.streak}
+                  currentExp={user.character.exp}
+                  totalExp={TOTAL_EXP}
+                  streakIcon={<StreakImoji className="h-7 w-7" aria-hidden="true" />}
+                  avatarBadge={
+                    isEditing ? (
+                      <ProfilePencilBadge
+                        onFileSelect={imageUpload.uploadFile}
+                        isLoading={imageUpload.isUploading}
+                        accept="image/jpeg,image/png,image/gif,image/webp,image/heic,image/heif"
+                      />
+                    ) : undefined
+                  }
+                  rightContent={
+                    isEditing ? (
+                      <ProfileNicknameEditForm
+                        authorId={authorId}
+                        initialNickname={user.profile.nickname}
+                        imageUpload={imageUpload}
+                        onDone={handleEditDone}
+                        onCancel={handleEditCancel}
+                      />
+                    ) : undefined
+                  }
+                  rightContentClassName="min-h-24"
+                />
+                <div className="absolute top-3 right-3 flex items-center gap-2">
+                  {isMyProfile && !isEditing && (
+                    <>
+                      <Chip
+                        label={MOMENTS_USER_FEED_MESSAGES.MY_FEED_LABEL}
+                        variant="default"
+                        size="sm"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setIsEditing(true)}
+                        className="text-text-muted text-sm underline"
+                      >
+                        {MOMENTS_USER_FEED_MESSAGES.EDIT_BUTTON}
+                      </button>
+                    </>
+                  )}
+                </div>
               </div>
-            </div>
-          )}
+            );
+          }}
         </LoadableBoundary>
       </div>
 

--- a/apps/web/src/shared/config/avatar.ts
+++ b/apps/web/src/shared/config/avatar.ts
@@ -1,0 +1,11 @@
+export const AVATAR_IMAGE_SIZES = {
+  SM: '40px',
+  MD: '48px',
+  LG: '64px',
+} as const;
+
+export const AVATAR_IMAGE_QUALITY = {
+  SM: 50,
+  MD: 60,
+  LG: 65,
+} as const;

--- a/apps/web/src/widgets/moments-post-detail/ui/PostDetailHeader.tsx
+++ b/apps/web/src/widgets/moments-post-detail/ui/PostDetailHeader.tsx
@@ -3,11 +3,13 @@ import { StreakBadge } from '@repo/ui/streak-badge';
 
 import type { PostAuthorType } from '@/src/entities/post';
 import { StreakImoji } from '@/src/shared/assets/StreakImoji';
+import { AVATAR_IMAGE_QUALITY, AVATAR_IMAGE_SIZES } from '@/src/shared/config/avatar';
 import {
   formatNotificationDateLabel,
   formatNotificationTimeLabel,
 } from '@/src/shared/lib/date/notification-date';
 import { buildImageUrl } from '@/src/shared/lib/image';
+import { OptimizedImage } from '@/src/shared/ui/optimized-image';
 
 interface PostDetailHeaderProps {
   author: PostAuthorType;
@@ -20,13 +22,27 @@ export function PostDetailHeader({ author, createdAt }: PostDetailHeaderProps) {
   const formattedDateTime = `${dateLabel} ${timeLabel}`;
 
   const profileImageUrl = buildImageUrl(author.profileImageUrl);
+  const avatarAlt = `${author.nickname} 프로필 이미지`;
 
   return (
     <div className="flex items-center gap-3 py-4">
       <Avatar
         src={profileImageUrl}
+        alt={avatarAlt}
         name={author.nickname}
         size="md"
+        imageSlot={
+          profileImageUrl ? (
+            <OptimizedImage
+              src={profileImageUrl}
+              alt={avatarAlt}
+              fill
+              className="object-cover"
+              quality={AVATAR_IMAGE_QUALITY.MD}
+              sizes={AVATAR_IMAGE_SIZES.MD}
+            />
+          ) : undefined
+        }
         badge={
           <StreakBadge
             streak={author.streak}

--- a/apps/web/src/widgets/post-author-info/ui/PostAuthorInfo.tsx
+++ b/apps/web/src/widgets/post-author-info/ui/PostAuthorInfo.tsx
@@ -3,11 +3,13 @@ import { StreakBadge } from '@repo/ui/streak-badge';
 
 import type { PostAuthorType } from '@/src/entities/post';
 import { StreakImoji } from '@/src/shared/assets/StreakImoji';
+import { AVATAR_IMAGE_QUALITY, AVATAR_IMAGE_SIZES } from '@/src/shared/config/avatar';
 import {
   formatNotificationDateLabel,
   formatNotificationTimeLabel,
 } from '@/src/shared/lib/date/notification-date';
 import { buildImageUrl } from '@/src/shared/lib/image';
+import { OptimizedImage } from '@/src/shared/ui/optimized-image';
 
 interface PostAuthorInfoProps {
   author: PostAuthorType;
@@ -21,13 +23,27 @@ export function PostAuthorInfo({ author, createdAt, onAuthorClick }: PostAuthorI
   const formattedDateTime = `${dateLabel} ${timeLabel}`;
 
   const profileImageUrl = buildImageUrl(author.profileImageUrl);
+  const avatarAlt = `${author.nickname} 프로필 이미지`;
 
   const authorContent = (
     <>
       <Avatar
         src={profileImageUrl}
+        alt={avatarAlt}
         name={author.nickname}
         size="md"
+        imageSlot={
+          profileImageUrl ? (
+            <OptimizedImage
+              src={profileImageUrl}
+              alt={avatarAlt}
+              fill
+              className="object-cover"
+              quality={AVATAR_IMAGE_QUALITY.MD}
+              sizes={AVATAR_IMAGE_SIZES.MD}
+            />
+          ) : undefined
+        }
         badge={
           <StreakBadge
             streak={author.streak}

--- a/packages/ui/src/avatar.tsx
+++ b/packages/ui/src/avatar.tsx
@@ -6,7 +6,7 @@ import { cn } from './lib/utils';
 
 const avatarVariants = cva(
   [
-    'inline-flex items-center justify-center overflow-hidden',
+    'relative inline-flex items-center justify-center overflow-hidden',
     'bg-bg-subtle text-text',
     'select-none',
   ],
@@ -40,6 +40,7 @@ export interface AvatarProps extends AvatarBaseProps, VariantProps<typeof avatar
   name?: string;
   fallbackText?: string;
   fallbackDelayMs?: number;
+  imageSlot?: React.ReactNode;
   badge?: React.ReactNode;
 }
 
@@ -62,6 +63,7 @@ export function Avatar({
   name,
   fallbackText,
   fallbackDelayMs = 0,
+  imageSlot,
   size,
   shape,
   badge,
@@ -74,17 +76,31 @@ export function Avatar({
   return (
     <div className="relative inline-flex">
       <AvatarPrimitive.Root className={cn(avatarVariants({ size, shape }), className)} {...props}>
-        <AvatarPrimitive.Image
-          src={src ?? undefined}
-          alt={ariaLabel}
-          className="h-full w-full object-cover"
-        />
-        <AvatarPrimitive.Fallback
-          delayMs={fallbackDelayMs}
-          className="flex h-full w-full items-center justify-center font-semibold"
-        >
-          {initials}
-        </AvatarPrimitive.Fallback>
+        {imageSlot ? (
+          <>
+            <div
+              aria-hidden="true"
+              className="flex h-full w-full items-center justify-center font-semibold"
+            >
+              {initials}
+            </div>
+            {imageSlot}
+          </>
+        ) : (
+          <>
+            <AvatarPrimitive.Image
+              src={src ?? undefined}
+              alt={ariaLabel}
+              className="h-full w-full object-cover"
+            />
+            <AvatarPrimitive.Fallback
+              delayMs={fallbackDelayMs}
+              className="flex h-full w-full items-center justify-center font-semibold"
+            >
+              {initials}
+            </AvatarPrimitive.Fallback>
+          </>
+        )}
       </AvatarPrimitive.Root>
 
       {badge && <div className="absolute -right-0.5 -bottom-0.5">{badge}</div>}

--- a/packages/ui/src/user-status-card.tsx
+++ b/packages/ui/src/user-status-card.tsx
@@ -13,6 +13,7 @@ export interface UserStatusCardProps extends Omit<
 > {
   avatarSrc?: string | null;
   avatarAlt?: string;
+  avatarImageSlot?: React.ReactNode;
   nickname: string;
   level: number;
   streak: number;
@@ -32,6 +33,7 @@ const getLevelLabel = (level: number) => {
 export function UserStatusCard({
   avatarSrc,
   avatarAlt,
+  avatarImageSlot,
   nickname,
   level,
   streak,
@@ -52,6 +54,7 @@ export function UserStatusCard({
           alt={avatarAlt ?? nickname}
           name={nickname}
           size="md"
+          imageSlot={avatarImageSlot}
           badge={avatarBadge ?? <StreakBadge streak={streak} icon={streakIcon} size="md" />}
         />
         <div className={cn('flex min-w-0 flex-1 flex-col gap-3', rightContentClassName)}>

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tooling/typescript-config/react-library.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist"
   },
   "include": ["src"],


### PR DESCRIPTION
🔷 Github Issue ID

- 작업한 내용에 해당하는 Issue 링크

📌 작업 내용 및 특이사항

### 변경 사항
- @repo/ui의 Avatar, UserStatusCard에 imageSlot 기반 확장 포인트를 추가
- /moments/[authorId] 유저 프로필 카드 아바타를 OptimizedImage로 렌더링하도록 변경
- /moments 목록 작성자, 상세 작성자 아바타도 동일하게 OptimizedImage를 사용하도록 함
- 아바타 전용 이미지 설정을 분리하고, md 프로필 아바타 품질을 60으로 조정 (sm : 50)

### 변경 이유
- 기존 /moments 프로필 아바타는 OptimizedImage 공통 래퍼를 사용하지 않아 이미지 최적화 정책이 적용되지 않았음
- 프로필 사진은 렌더 크기가 작아 기본 품질보다 낮은 값이 더 적절하다고 판단해 아바타 전용 품질 설정을 분리

📚 참고사항

- PR 리뷰 과정에서 참고하면 좋을 내용들

Closes #
