### PR TITLE
[#373] ssr 사용 후 meta 를 hydrate 하는 구조 적용

### DIFF
--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,14 +1,20 @@
-import { MomentsPage } from '@/src/pages/moments';
+import {
+  getMomentsPageServerSideProps,
+  MomentsPage,
+  type MomentsPageProps,
+} from '@/src/pages/moments';
 import { MOMENTS_PAGE_MESSAGES } from '@/src/pages/moments/config/messages';
 import { createPublicLayout } from '@/src/shared/lib/layout';
 import type { NextPageWithLayout } from '@/src/shared/types';
 
-const Page: NextPageWithLayout = MomentsPage;
+const Page: NextPageWithLayout<MomentsPageProps> = MomentsPage;
 Page.getLayout = createPublicLayout({
   headerConfig: {
     variant: 'sub',
     title: MOMENTS_PAGE_MESSAGES.TITLE,
   },
 });
+
+export const getServerSideProps = getMomentsPageServerSideProps;
 
 export default Page;

--- a/apps/web/pages/moments/index.tsx
+++ b/apps/web/pages/moments/index.tsx
@@ -1,9 +1,13 @@
-import { MomentsPage } from '@/src/pages/moments';
+import {
+  getMomentsPageServerSideProps,
+  MomentsPage,
+  type MomentsPageProps,
+} from '@/src/pages/moments';
 import { MOMENTS_PAGE_MESSAGES } from '@/src/pages/moments/config/messages';
 import { createPublicLayout } from '@/src/shared/lib/layout';
 import type { NextPageWithLayout } from '@/src/shared/types';
 
-const Page: NextPageWithLayout = MomentsPage;
+const Page: NextPageWithLayout<MomentsPageProps> = MomentsPage;
 Page.getLayout = createPublicLayout({
   headerConfig: {
     variant: 'sub',
@@ -11,5 +15,7 @@ Page.getLayout = createPublicLayout({
     back: true,
   },
 });
+
+export const getServerSideProps = getMomentsPageServerSideProps;
 
 export default Page;

--- a/apps/web/src/entities/post/api/post-list.ts
+++ b/apps/web/src/entities/post/api/post-list.ts
@@ -55,3 +55,20 @@ export async function fetchPostListPageFn(
 
   return response.data.data;
 }
+
+export async function fetchPublicPostListPageFn(
+  params: PostListParams,
+): Promise<PostListResponseDataType> {
+  const client = getHttpClient({ requiresAuth: false });
+  const response = await client.get<PostListResponseDTO>('/posts', {
+    params: {
+      limit: params.limit,
+      cursor: params.cursor ?? undefined,
+      'author-id': params.authorId ?? undefined,
+      tag: params.tags,
+    },
+    paramsSerializer: createQueryString,
+  });
+
+  return response.data.data;
+}

--- a/apps/web/src/entities/post/api/query-options.ts
+++ b/apps/web/src/entities/post/api/query-options.ts
@@ -7,12 +7,16 @@ import {
 
 import type { ApiError } from '@/src/shared/api';
 
-import { POST_QUERY_KEYS, type PostListQueryParams } from '../config/query-keys';
+import {
+  POST_QUERY_KEYS,
+  type PostListPageQueryParams,
+  type PostListQueryParams,
+} from '../config/query-keys';
 import type { PostDetailDataType } from './dto/post-detail.dto';
 import type { PostListResponseDataType } from './dto/post-list.dto';
-import type { PostMetaDataType } from './dto/post-meta.dto';
+import type { PostListMetaDataType, PostMetaDataType } from './dto/post-meta.dto';
 import { fetchPostDetailFn } from './post-detail';
-import { fetchPostListPageFn } from './post-list';
+import { fetchPublicPostListPageFn } from './post-list';
 import { fetchPostListMetaFn, fetchPostMetaFn } from './post-meta';
 
 const DEFAULT_MAX_PAGES = 10;
@@ -21,6 +25,8 @@ export type PostDetailQueryKey = ReturnType<typeof POST_QUERY_KEYS.detail>;
 export type PostDetailMetaQueryKey = ReturnType<typeof POST_QUERY_KEYS.meta>;
 export type PostListInfiniteQueryKey = ReturnType<typeof POST_QUERY_KEYS.list>;
 export type PostListRootQueryKey = ReturnType<typeof POST_QUERY_KEYS.listRoot>;
+export type PostListMetaPageQueryKey = ReturnType<typeof POST_QUERY_KEYS.listMetaPage>;
+export type PostListMetaPageRootQueryKey = ReturnType<typeof POST_QUERY_KEYS.listMetaPageRoot>;
 
 export type PostListInfiniteQueryOptions = Omit<
   UseInfiniteQueryOptions<
@@ -60,54 +66,28 @@ export function postListRootQueryOptions() {
   });
 }
 
-async function fetchPostListWithMeta(
-  params: PostListQueryParams,
-  isLoggedIn: boolean,
-  pageParam: string | null,
-): Promise<PostListResponseDataType> {
-  const cursor = pageParam ?? undefined;
-  const baseParams = {
-    limit: params.limit,
-    authorId: params.authorId,
-    tags: params.tags,
-    cursor,
-  };
+export function postListMetaPageRootQueryOptions() {
+  return queryOptions<unknown, ApiError, unknown, PostListMetaPageRootQueryKey>({
+    queryKey: POST_QUERY_KEYS.listMetaPageRoot(),
+  });
+}
 
-  if (!isLoggedIn) {
-    return fetchPostListPageFn(baseParams);
-  }
-
-  const [mainResult, metaResult] = await Promise.allSettled([
-    fetchPostListPageFn(baseParams),
-    fetchPostListMetaFn(baseParams),
-  ]);
-
-  if (mainResult.status === 'rejected') {
-    throw mainResult.reason;
-  }
-  const mainData = mainResult.value;
-
-  if (metaResult.status === 'rejected' || !metaResult.value) {
-    return mainData;
-  }
-
-  const metaMap = new Map(metaResult.value.posts.map((meta) => [meta.postId, meta]));
-  return {
-    ...mainData,
-    posts: mainData.posts.map((post) => {
-      const meta = metaMap.get(post.postId);
-      if (!meta) {
-        return post;
-      }
-
-      return { ...post, ...meta };
-    }),
-  };
+export function postListMetaPageQueryOptions(params: PostListPageQueryParams) {
+  return queryOptions<
+    PostListMetaDataType | null,
+    ApiError,
+    PostListMetaDataType | null,
+    PostListMetaPageQueryKey
+  >({
+    queryKey: POST_QUERY_KEYS.listMetaPage(params),
+    queryFn: () => fetchPostListMetaFn(params),
+    throwOnError: false,
+    retry: false,
+  });
 }
 
 export function postListInfiniteQueryOptions(
   params: PostListQueryParams,
-  isLoggedIn = false,
   maxPages = DEFAULT_MAX_PAGES,
 ) {
   return infiniteQueryOptions<
@@ -117,8 +97,14 @@ export function postListInfiniteQueryOptions(
     PostListInfiniteQueryKey,
     string | null
   >({
-    queryKey: POST_QUERY_KEYS.list(params, isLoggedIn),
-    queryFn: ({ pageParam }) => fetchPostListWithMeta(params, isLoggedIn, pageParam),
+    queryKey: POST_QUERY_KEYS.list(params),
+    queryFn: ({ pageParam }) =>
+      fetchPublicPostListPageFn({
+        limit: params.limit,
+        authorId: params.authorId,
+        tags: params.tags,
+        cursor: pageParam ?? undefined,
+      }),
     maxPages,
     initialPageParam: null,
     getNextPageParam: (lastPage) => {

--- a/apps/web/src/entities/post/config/query-keys.ts
+++ b/apps/web/src/entities/post/config/query-keys.ts
@@ -4,11 +4,25 @@ export type PostListQueryParams = {
   tags?: string[];
 };
 
+export type PostListPageQueryParams = PostListQueryParams & {
+  cursor?: string | null;
+};
+
 export const POST_QUERY_KEYS = {
   root: () => ['post'] as const,
   detail: (postId: number) => [...POST_QUERY_KEYS.root(), 'detail', postId] as const,
   meta: (postId: number) => [...POST_QUERY_KEYS.root(), 'meta', postId] as const,
   listRoot: () => [...POST_QUERY_KEYS.root(), 'list'] as const,
-  list: (params: PostListQueryParams, isLoggedIn?: boolean) =>
-    [...POST_QUERY_KEYS.listRoot(), params, { isLoggedIn: !!isLoggedIn }] as const,
+  list: (params: PostListQueryParams) => [...POST_QUERY_KEYS.listRoot(), params] as const,
+  listMetaPageRoot: () => [...POST_QUERY_KEYS.root(), 'list-meta-page'] as const,
+  listMetaPage: (params: PostListPageQueryParams) =>
+    [
+      ...POST_QUERY_KEYS.listMetaPageRoot(),
+      {
+        limit: params.limit,
+        authorId: params.authorId,
+        tags: params.tags,
+        cursor: params.cursor ?? null,
+      },
+    ] as const,
 } as const;

--- a/apps/web/src/entities/post/index.ts
+++ b/apps/web/src/entities/post/index.ts
@@ -27,7 +27,7 @@ export {
   uploadPostImageToPresignedPutFn,
 } from './api/post-image-upload';
 export { togglePostLikeFn } from './api/post-like';
-export { fetchPostListPageFn } from './api/post-list';
+export { fetchPostListPageFn, fetchPublicPostListPageFn } from './api/post-list';
 export { fetchPostListMetaFn, fetchPostMetaFn } from './api/post-meta';
 export { updatePostFn } from './api/post-update';
 export type {
@@ -35,13 +35,17 @@ export type {
   PostDetailQueryKey,
   PostListInfiniteQueryKey,
   PostListInfiniteQueryOptions,
+  PostListMetaPageQueryKey,
+  PostListMetaPageRootQueryKey,
   PostListRootQueryKey,
 } from './api/query-options';
 export {
   postDetailMetaQueryOptions,
   postDetailQueryOptions,
   postListInfiniteQueryOptions,
+  postListMetaPageQueryOptions,
+  postListMetaPageRootQueryOptions,
   postListRootQueryOptions,
 } from './api/query-options';
-export type { PostListQueryParams } from './config/query-keys';
+export type { PostListPageQueryParams, PostListQueryParams } from './config/query-keys';
 export { POST_QUERY_KEYS } from './config/query-keys';

--- a/apps/web/src/features/moments-like/model/optimistic-update-helpers.ts
+++ b/apps/web/src/features/moments-like/model/optimistic-update-helpers.ts
@@ -1,6 +1,11 @@
 import type { InfiniteData, QueryClient, QueryKey } from '@tanstack/react-query';
 
-import type { PostListItemType, PostListResponseDataType } from '@/src/entities/post';
+import type {
+  PostListItemType,
+  PostListMetaDataType,
+  PostListMetaItemType,
+  PostListResponseDataType,
+} from '@/src/entities/post';
 
 import { MOMENTS_LIKE_CACHE_TARGETS } from './query-options';
 
@@ -15,9 +20,23 @@ interface MomentsListQueryUpdate {
   nextData: InfiniteData<PostListResponseDataType>;
 }
 
+interface MomentsListMetaPageQuerySnapshot {
+  queryKey: QueryKey;
+  data: PostListMetaDataType | null | undefined;
+}
+
+interface MomentsListMetaPageQueryUpdate {
+  queryKey: QueryKey;
+  previousData: PostListMetaDataType | null | undefined;
+  nextData: PostListMetaDataType;
+}
+
 type LikePatch = { type: 'toggle' } | { type: 'sync'; isLiked: boolean };
 
-function resolveLikeCount(current: PostListItemType, patch: LikePatch) {
+function resolveLikeCount(
+  current: Pick<PostListItemType, 'isLiked' | 'likeCount'>,
+  patch: LikePatch,
+) {
   if (patch.type === 'toggle') {
     if (current.isLiked) {
       return Math.max(0, current.likeCount - 1);
@@ -36,12 +55,27 @@ function resolveLikeCount(current: PostListItemType, patch: LikePatch) {
   return Math.max(0, current.likeCount - 1);
 }
 
-function resolveLikeState(current: PostListItemType, patch: LikePatch) {
+function resolveLikeState(current: Pick<PostListItemType, 'isLiked'>, patch: LikePatch) {
   if (patch.type === 'toggle') {
     return !current.isLiked;
   }
 
   return patch.isLiked;
+}
+
+function patchMetaItemLikeState(current: PostListMetaItemType, patch: LikePatch) {
+  const nextIsLiked = resolveLikeState(current, patch);
+  const nextLikeCount = resolveLikeCount(current, patch);
+
+  if (current.isLiked === nextIsLiked && current.likeCount === nextLikeCount) {
+    return current;
+  }
+
+  return {
+    ...current,
+    isLiked: nextIsLiked,
+    likeCount: nextLikeCount,
+  };
 }
 
 //리스트에서 좋아요 누를 때
@@ -104,6 +138,16 @@ export function getMomentsListQuerySnapshots(queryClient: QueryClient): MomentsL
     .map(([queryKey, data]) => ({ queryKey, data }));
 }
 
+export function getMomentsListMetaPageQuerySnapshots(
+  queryClient: QueryClient,
+): MomentsListMetaPageQuerySnapshot[] {
+  const metaPageRootOptions = MOMENTS_LIKE_CACHE_TARGETS.momentsListMetaPageRoot();
+
+  return queryClient
+    .getQueriesData<PostListMetaDataType | null>(metaPageRootOptions)
+    .map(([queryKey, data]) => ({ queryKey, data }));
+}
+
 function createMomentsListQueryUpdates(
   snapshots: MomentsListQuerySnapshot[],
   postId: number,
@@ -150,10 +194,81 @@ export function applyMomentsListQueryUpdates(
   });
 }
 
+function createMomentsListMetaPageQueryUpdates(
+  snapshots: MomentsListMetaPageQuerySnapshot[],
+  postId: number,
+  patch: LikePatch,
+): MomentsListMetaPageQueryUpdate[] {
+  const updates: MomentsListMetaPageQueryUpdate[] = [];
+
+  snapshots.forEach(({ queryKey, data }) => {
+    if (!data) return;
+
+    let nextPosts: PostListMetaItemType[] | null = null;
+
+    data.posts.forEach((post, index) => {
+      if (post.postId !== postId) return;
+
+      const nextPost = patchMetaItemLikeState(post, patch);
+      if (nextPost === post) return;
+
+      if (!nextPosts) {
+        nextPosts = [...data.posts];
+      }
+
+      nextPosts[index] = nextPost;
+    });
+
+    if (!nextPosts) return;
+
+    updates.push({
+      queryKey,
+      previousData: data,
+      nextData: {
+        ...data,
+        posts: nextPosts,
+      },
+    });
+  });
+
+  return updates;
+}
+
+export function getToggleMomentsListMetaPageQueryUpdates(
+  snapshots: MomentsListMetaPageQuerySnapshot[],
+  postId: number,
+): MomentsListMetaPageQueryUpdate[] {
+  return createMomentsListMetaPageQueryUpdates(snapshots, postId, { type: 'toggle' });
+}
+
+export function getSyncMomentsListMetaPageQueryUpdates(
+  snapshots: MomentsListMetaPageQuerySnapshot[],
+  postId: number,
+  nextIsLiked: boolean,
+): MomentsListMetaPageQueryUpdate[] {
+  return createMomentsListMetaPageQueryUpdates(snapshots, postId, {
+    type: 'sync',
+    isLiked: nextIsLiked,
+  });
+}
+
+export function applyMomentsListMetaPageQueryUpdates(
+  queryClient: QueryClient,
+  updates: MomentsListMetaPageQueryUpdate[],
+) {
+  updates.forEach(({ queryKey, nextData }) => {
+    queryClient.setQueryData<PostListMetaDataType | null>(queryKey, nextData);
+  });
+}
+
 export function togglePostLikeInAllMomentsListQueries(queryClient: QueryClient, postId: number) {
-  const snapshots = getMomentsListQuerySnapshots(queryClient);
-  const updates = getToggleMomentsListQueryUpdates(snapshots, postId);
-  applyMomentsListQueryUpdates(queryClient, updates);
+  const baseSnapshots = getMomentsListQuerySnapshots(queryClient);
+  const baseUpdates = getToggleMomentsListQueryUpdates(baseSnapshots, postId);
+  const metaSnapshots = getMomentsListMetaPageQuerySnapshots(queryClient);
+  const metaUpdates = getToggleMomentsListMetaPageQueryUpdates(metaSnapshots, postId);
+
+  applyMomentsListQueryUpdates(queryClient, baseUpdates);
+  applyMomentsListMetaPageQueryUpdates(queryClient, metaUpdates);
 }
 
 export function syncPostLikeInAllMomentsListQueries(
@@ -161,7 +276,11 @@ export function syncPostLikeInAllMomentsListQueries(
   postId: number,
   nextIsLiked: boolean,
 ) {
-  const snapshots = getMomentsListQuerySnapshots(queryClient);
-  const updates = getSyncMomentsListQueryUpdates(snapshots, postId, nextIsLiked);
-  applyMomentsListQueryUpdates(queryClient, updates);
+  const baseSnapshots = getMomentsListQuerySnapshots(queryClient);
+  const baseUpdates = getSyncMomentsListQueryUpdates(baseSnapshots, postId, nextIsLiked);
+  const metaSnapshots = getMomentsListMetaPageQuerySnapshots(queryClient);
+  const metaUpdates = getSyncMomentsListMetaPageQueryUpdates(metaSnapshots, postId, nextIsLiked);
+
+  applyMomentsListQueryUpdates(queryClient, baseUpdates);
+  applyMomentsListMetaPageQueryUpdates(queryClient, metaUpdates);
 }

--- a/apps/web/src/features/moments-like/model/query-options.ts
+++ b/apps/web/src/features/moments-like/model/query-options.ts
@@ -1,10 +1,14 @@
-import { postListRootQueryOptions } from '@/src/entities/post';
+import { postListMetaPageRootQueryOptions, postListRootQueryOptions } from '@/src/entities/post';
 
 //좋아요 동기화 대상 캐시를 정의
 export const MOMENTS_LIKE_CACHE_TARGETS = {
+  momentsListMetaPageRoot: postListMetaPageRootQueryOptions,
   momentsListRoot: postListRootQueryOptions,
 } as const;
 
+export type MomentsLikeTargetListMetaPageRootQueryKey = ReturnType<
+  (typeof MOMENTS_LIKE_CACHE_TARGETS)['momentsListMetaPageRoot']
+>['queryKey'];
 export type MomentsLikeTargetListRootQueryKey = ReturnType<
   (typeof MOMENTS_LIKE_CACHE_TARGETS)['momentsListRoot']
 >['queryKey'];

--- a/apps/web/src/features/moments-like/model/useLikePostMutationOptions.ts
+++ b/apps/web/src/features/moments-like/model/useLikePostMutationOptions.ts
@@ -8,16 +8,24 @@ import {
 
 import type { LikePostMutationOptions } from '../api/useLikePostMutation';
 import {
+  applyMomentsListMetaPageQueryUpdates,
   applyMomentsListQueryUpdates,
+  getMomentsListMetaPageQuerySnapshots,
   getMomentsListQuerySnapshots,
+  getSyncMomentsListMetaPageQueryUpdates,
   getSyncMomentsListQueryUpdates,
+  getToggleMomentsListMetaPageQueryUpdates,
   getToggleMomentsListQueryUpdates,
 } from './optimistic-update-helpers';
 
 interface LikePostOptimisticContext {
-  previousQueries: Array<{
+  previousBaseQueries: Array<{
     queryKey: ReturnType<typeof getMomentsListQuerySnapshots>[number]['queryKey'];
     data: ReturnType<typeof getMomentsListQuerySnapshots>[number]['data'];
+  }>;
+  previousMetaPageQueries: Array<{
+    queryKey: ReturnType<typeof getMomentsListMetaPageQuerySnapshots>[number]['queryKey'];
+    data: ReturnType<typeof getMomentsListMetaPageQuerySnapshots>[number]['data'];
   }>;
   previousDetailMeta: {
     queryKey: ReturnType<typeof postDetailMetaQueryOptions>['queryKey'];
@@ -28,7 +36,8 @@ interface LikePostOptimisticContext {
 function isLikePostOptimisticContext(context: unknown): context is LikePostOptimisticContext {
   if (!context) return false;
   if (typeof context !== 'object') return false;
-  if (!('previousQueries' in context)) return false;
+  if (!('previousBaseQueries' in context)) return false;
+  if (!('previousMetaPageQueries' in context)) return false;
   if (!('previousDetailMeta' in context)) return false;
   return true;
 }
@@ -54,11 +63,20 @@ export function useLikePostMutationOptions(): LikePostMutationOptions {
 
   return {
     onMutate: async (variables) => {
-      const snapshots = getMomentsListQuerySnapshots(queryClient);
-      const updates = getToggleMomentsListQueryUpdates(snapshots, variables.postId);
+      const baseSnapshots = getMomentsListQuerySnapshots(queryClient);
+      const baseUpdates = getToggleMomentsListQueryUpdates(baseSnapshots, variables.postId);
+      const metaPageSnapshots = getMomentsListMetaPageQuerySnapshots(queryClient);
+      const metaPageUpdates = getToggleMomentsListMetaPageQueryUpdates(
+        metaPageSnapshots,
+        variables.postId,
+      );
       const detailMetaQueryKey = postDetailMetaQueryOptions(variables.postId).queryKey;
 
-      const previousQueries = updates.map(({ queryKey, previousData }) => ({
+      const previousBaseQueries = baseUpdates.map(({ queryKey, previousData }) => ({
+        queryKey,
+        data: previousData,
+      }));
+      const previousMetaPageQueries = metaPageUpdates.map(({ queryKey, previousData }) => ({
         queryKey,
         data: previousData,
       }));
@@ -68,17 +86,20 @@ export function useLikePostMutationOptions(): LikePostMutationOptions {
       );
 
       await Promise.all([
-        ...previousQueries.map(({ queryKey }) => queryClient.cancelQueries({ queryKey })),
+        ...previousBaseQueries.map(({ queryKey }) => queryClient.cancelQueries({ queryKey })),
+        ...previousMetaPageQueries.map(({ queryKey }) => queryClient.cancelQueries({ queryKey })),
         queryClient.cancelQueries({ queryKey: detailMetaQueryKey }),
       ]);
 
-      applyMomentsListQueryUpdates(queryClient, updates);
+      applyMomentsListQueryUpdates(queryClient, baseUpdates);
+      applyMomentsListMetaPageQueryUpdates(queryClient, metaPageUpdates);
       queryClient.setQueryData<PostMetaDataType | null>(detailMetaQueryKey, (old) =>
         patchDetailMetaLikeState(old, !variables.isLiked),
       );
 
       return {
-        previousQueries,
+        previousBaseQueries,
+        previousMetaPageQueries,
         previousDetailMeta: {
           queryKey: detailMetaQueryKey,
           data: previousDetailMeta,
@@ -89,7 +110,11 @@ export function useLikePostMutationOptions(): LikePostMutationOptions {
     onError: (_error, _variables, context) => {
       if (!isLikePostOptimisticContext(context)) return;
 
-      context.previousQueries.forEach(({ queryKey, data }) => {
+      context.previousBaseQueries.forEach(({ queryKey, data }) => {
+        if (data === undefined) return;
+        queryClient.setQueryData(queryKey, data);
+      });
+      context.previousMetaPageQueries.forEach(({ queryKey, data }) => {
         if (data === undefined) return;
         queryClient.setQueryData(queryKey, data);
       });
@@ -104,9 +129,20 @@ export function useLikePostMutationOptions(): LikePostMutationOptions {
     onSuccess: (responseData, variables) => {
       const serverData = responseData as PostLikeDataType;
       const targetPostId = serverData.postId ?? variables.postId;
-      const snapshots = getMomentsListQuerySnapshots(queryClient);
-      const updates = getSyncMomentsListQueryUpdates(snapshots, targetPostId, serverData.isLiked);
-      applyMomentsListQueryUpdates(queryClient, updates);
+      const baseSnapshots = getMomentsListQuerySnapshots(queryClient);
+      const baseUpdates = getSyncMomentsListQueryUpdates(
+        baseSnapshots,
+        targetPostId,
+        serverData.isLiked,
+      );
+      const metaPageSnapshots = getMomentsListMetaPageQuerySnapshots(queryClient);
+      const metaPageUpdates = getSyncMomentsListMetaPageQueryUpdates(
+        metaPageSnapshots,
+        targetPostId,
+        serverData.isLiked,
+      );
+      applyMomentsListQueryUpdates(queryClient, baseUpdates);
+      applyMomentsListMetaPageQueryUpdates(queryClient, metaPageUpdates);
 
       const detailMetaQueryKey = postDetailMetaQueryOptions(targetPostId).queryKey;
       queryClient.setQueryData<PostMetaDataType | null>(detailMetaQueryKey, (old) =>

--- a/apps/web/src/features/moments-list/api/query-options.ts
+++ b/apps/web/src/features/moments-list/api/query-options.ts
@@ -2,6 +2,8 @@ import {
   type PostListInfiniteQueryKey,
   type PostListInfiniteQueryOptions,
   postListInfiniteQueryOptions,
+  type PostListMetaPageRootQueryKey,
+  postListMetaPageRootQueryOptions,
   type PostListRootQueryKey,
   postListRootQueryOptions,
 } from '@/src/entities/post';
@@ -10,14 +12,13 @@ import { MOMENTS_LIST_CONFIG } from '../config/constants';
 import type { MomentsListQueryParams } from '../model/types';
 
 export type MomentsListInfiniteQueryKey = PostListInfiniteQueryKey;
+export type MomentsListMetaPageRootQueryKey = PostListMetaPageRootQueryKey;
 export type MomentsListRootQueryKey = PostListRootQueryKey;
 export type MomentsListInfiniteQueryOptions = PostListInfiniteQueryOptions;
 
+export { postListMetaPageRootQueryOptions as momentsListMetaPageRootQueryOptions };
 export { postListRootQueryOptions as momentsListRootQueryOptions };
 
-export function momentsListInfiniteQueryOptions(
-  params: MomentsListQueryParams,
-  isLoggedIn = false,
-) {
-  return postListInfiniteQueryOptions(params, isLoggedIn, MOMENTS_LIST_CONFIG.MAX_PAGES);
+export function momentsListInfiniteQueryOptions(params: MomentsListQueryParams) {
+  return postListInfiniteQueryOptions(params, MOMENTS_LIST_CONFIG.MAX_PAGES);
 }

--- a/apps/web/src/features/moments-list/api/useMomentsFeedQuery.ts
+++ b/apps/web/src/features/moments-list/api/useMomentsFeedQuery.ts
@@ -1,0 +1,138 @@
+import { type InfiniteData, useQueries } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import {
+  type PostListMetaDataType,
+  postListMetaPageQueryOptions,
+  type PostListPageQueryParams,
+  type PostListResponseDataType,
+} from '@/src/entities/post';
+
+import type { MomentsListQueryParams } from '../model/types';
+import { usePostsInfiniteQuery } from './usePostsInfiniteQuery';
+
+interface MomentsFeedQueryOptions {
+  isLoggedIn?: boolean;
+  initialPageData?: PostListResponseDataType;
+  initialListParams?: MomentsListQueryParams;
+}
+
+function areMomentsListParamsEqual(
+  currentParams: MomentsListQueryParams,
+  initialParams?: MomentsListQueryParams,
+) {
+  if (!initialParams) return false;
+  if (currentParams.limit !== initialParams.limit) return false;
+  if (currentParams.authorId !== initialParams.authorId) return false;
+
+  const currentTags = currentParams.tags ?? [];
+  const initialTags = initialParams.tags ?? [];
+
+  if (currentTags.length !== initialTags.length) return false;
+
+  return currentTags.every((tag, index) => tag === initialTags[index]);
+}
+
+function buildInitialInfiniteData(
+  initialPageData?: PostListResponseDataType,
+): InfiniteData<PostListResponseDataType, string | null> | undefined {
+  if (!initialPageData) return undefined;
+
+  return {
+    pages: [initialPageData],
+    pageParams: [null],
+  };
+}
+
+function buildMetaPageParams(
+  data: InfiniteData<PostListResponseDataType, unknown> | undefined,
+  params: MomentsListQueryParams,
+): PostListPageQueryParams[] {
+  if (!data) return [];
+
+  return data.pages.map((_page, index) => ({
+    limit: params.limit,
+    authorId: params.authorId,
+    tags: params.tags,
+    cursor: (data.pageParams[index] as string | null | undefined) ?? null,
+  }));
+}
+
+function mergePostsWithMeta(
+  data: InfiniteData<PostListResponseDataType, unknown> | undefined,
+  metaPages: Array<PostListMetaDataType | null | undefined>,
+) {
+  if (!data) return data;
+
+  return {
+    ...data,
+    pages: data.pages.map((page, index) => {
+      const metaPage = metaPages[index];
+
+      if (!metaPage?.posts.length) {
+        return page;
+      }
+
+      const metaMap = new Map(metaPage.posts.map((meta) => [meta.postId, meta]));
+
+      return {
+        ...page,
+        posts: page.posts.map((post) => {
+          const meta = metaMap.get(post.postId);
+
+          if (!meta) {
+            return post;
+          }
+
+          return {
+            ...post,
+            likeCount: meta.likeCount,
+            isLiked: meta.isLiked,
+          };
+        }),
+      };
+    }),
+  };
+}
+
+export function useMomentsFeedQuery(
+  params: MomentsListQueryParams,
+  options?: MomentsFeedQueryOptions,
+) {
+  const isLoggedIn = options?.isLoggedIn ?? false;
+  const shouldUseInitialData =
+    !!options?.initialPageData && areMomentsListParamsEqual(params, options.initialListParams);
+
+  const baseQuery = usePostsInfiniteQuery(params, {
+    initialData: shouldUseInitialData
+      ? buildInitialInfiniteData(options?.initialPageData)
+      : undefined,
+    refetchOnMount: shouldUseInitialData ? false : undefined,
+  });
+
+  const metaPageParams = useMemo(
+    () => (isLoggedIn ? buildMetaPageParams(baseQuery.data, params) : []),
+    [baseQuery.data, isLoggedIn, params],
+  );
+
+  const metaQueries = useQueries({
+    queries: metaPageParams.map((metaParams) => ({
+      ...postListMetaPageQueryOptions(metaParams),
+      enabled: isLoggedIn,
+    })),
+  });
+
+  const mergedData = useMemo(
+    () =>
+      mergePostsWithMeta(
+        baseQuery.data,
+        metaQueries.map((query) => query.data),
+      ),
+    [baseQuery.data, metaQueries],
+  );
+
+  return {
+    ...baseQuery,
+    data: mergedData,
+  };
+}

--- a/apps/web/src/features/moments-list/api/usePostsInfiniteQuery.ts
+++ b/apps/web/src/features/moments-list/api/usePostsInfiniteQuery.ts
@@ -12,12 +12,10 @@ type MomentsListInfiniteQueryOptions = PostListInfiniteQueryOptions;
 
 export function usePostsInfiniteQuery(
   params: MomentsListQueryParams,
-  options?: MomentsListInfiniteQueryOptions & { isLoggedIn?: boolean },
+  options?: MomentsListInfiniteQueryOptions,
 ) {
-  const { isLoggedIn = false, ...queryOverrides } = options ?? {};
-
   return useInfiniteQuery({
-    ...postListInfiniteQueryOptions(params, isLoggedIn, MOMENTS_LIST_CONFIG.MAX_PAGES),
-    ...queryOverrides,
+    ...postListInfiniteQueryOptions(params, MOMENTS_LIST_CONFIG.MAX_PAGES),
+    ...(options ?? {}),
   });
 }

--- a/apps/web/src/features/moments-list/config/query-keys.ts
+++ b/apps/web/src/features/moments-list/config/query-keys.ts
@@ -4,6 +4,6 @@ import type { MomentsListQueryParams } from '../model/types';
 
 export const MOMENTS_LIST_QUERY_KEYS = {
   root: POST_QUERY_KEYS.listRoot,
-  list: (params: MomentsListQueryParams, isLoggedIn?: boolean) =>
-    POST_QUERY_KEYS.list(params, isLoggedIn),
+  metaPageRoot: POST_QUERY_KEYS.listMetaPageRoot,
+  list: (params: MomentsListQueryParams) => POST_QUERY_KEYS.list(params),
 } as const;

--- a/apps/web/src/features/moments-list/index.ts
+++ b/apps/web/src/features/moments-list/index.ts
@@ -1,4 +1,9 @@
-export { momentsListInfiniteQueryOptions, momentsListRootQueryOptions } from './api/query-options';
+export {
+  momentsListInfiniteQueryOptions,
+  momentsListMetaPageRootQueryOptions,
+  momentsListRootQueryOptions,
+} from './api/query-options';
+export { useMomentsFeedQuery } from './api/useMomentsFeedQuery';
 export { usePostsInfiniteQuery } from './api/usePostsInfiniteQuery';
 export { MOMENTS_LIST_CONFIG } from './config/constants';
 export { MOMENTS_LIST_MESSAGES } from './config/messages';

--- a/apps/web/src/pages/moments-detail/ui/MomentsDetailPage.tsx
+++ b/apps/web/src/pages/moments-detail/ui/MomentsDetailPage.tsx
@@ -7,7 +7,10 @@ import { useDeletePostMutation } from '@/src/features/moments-detail/api/useDele
 import { usePostDetailMetaQuery } from '@/src/features/moments-detail/api/usePostDetailMetaQuery';
 import { usePostDetailQuery } from '@/src/features/moments-detail/api/usePostDetailQuery';
 import { PostDetailMenu } from '@/src/features/moments-detail/ui/PostDetailMenu';
-import { momentsListRootQueryOptions } from '@/src/features/moments-list';
+import {
+  momentsListMetaPageRootQueryOptions,
+  momentsListRootQueryOptions,
+} from '@/src/features/moments-list';
 import { useOnboardingStatusQuery } from '@/src/features/onboarding-status';
 import { isApiError } from '@/src/shared/api';
 import { LoadableBoundary } from '@/src/shared/ui/boundary/LoadableBoundary';
@@ -32,7 +35,7 @@ export function MomentsDetailPage({ initialData }: MomentsDetailPageProps) {
 
   const { data, error, isLoading } = usePostDetailQuery(postId, {
     enabled: isPostIdValid,
-    // placeholderData: initialData,
+    initialData,
   });
 
   const { data: metaData } = usePostDetailMetaQuery(postId, {
@@ -48,7 +51,12 @@ export function MomentsDetailPage({ initialData }: MomentsDetailPageProps) {
 
   const { mutate: deletePost, isPending: isDeleting } = useDeletePostMutation({
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: momentsListRootQueryOptions().queryKey });
+      void Promise.all([
+        queryClient.invalidateQueries({ queryKey: momentsListRootQueryOptions().queryKey }),
+        queryClient.invalidateQueries({
+          queryKey: momentsListMetaPageRootQueryOptions().queryKey,
+        }),
+      ]);
       router.replace('/moments');
     },
   });

--- a/apps/web/src/pages/moments-edit/ui/MomentsEditPage.tsx
+++ b/apps/web/src/pages/moments-edit/ui/MomentsEditPage.tsx
@@ -7,7 +7,10 @@ import { useCallback, useState } from 'react';
 import type { PostDetailDataType } from '@/src/entities/post';
 import { postDetailQueryOptions, usePostDetailQuery } from '@/src/features/moments-detail';
 import { MOMENTS_EDIT_MESSAGES, useUpdatePostMutation } from '@/src/features/moments-edit';
-import { momentsListRootQueryOptions } from '@/src/features/moments-list';
+import {
+  momentsListMetaPageRootQueryOptions,
+  momentsListRootQueryOptions,
+} from '@/src/features/moments-list';
 import { isApiError } from '@/src/shared/api';
 import type { MomentsPostFormValues } from '@/src/shared/types';
 import { LoadableBoundary } from '@/src/shared/ui/boundary/LoadableBoundary';
@@ -81,6 +84,7 @@ export function MomentsEditPage() {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: postDetailQueryOptions(postId).queryKey }),
       queryClient.invalidateQueries({ queryKey: momentsListRootQueryOptions().queryKey }),
+      queryClient.invalidateQueries({ queryKey: momentsListMetaPageRootQueryOptions().queryKey }),
     ]);
     router.replace(`/moments/post/${postId}`);
   }, [isPostIdValid, postId, queryClient, router]);

--- a/apps/web/src/pages/moments-new/ui/MomentsNewPage.tsx
+++ b/apps/web/src/pages/moments-new/ui/MomentsNewPage.tsx
@@ -4,7 +4,10 @@ import { useRouter } from 'next/router';
 import { useCallback, useState } from 'react';
 
 import { MOMENTS_CREATE_MESSAGES, useCreatePostMutation } from '@/src/features/moments-create';
-import { momentsListRootQueryOptions } from '@/src/features/moments-list';
+import {
+  momentsListMetaPageRootQueryOptions,
+  momentsListRootQueryOptions,
+} from '@/src/features/moments-list';
 import type { MomentsPostFormValues } from '@/src/shared/types';
 import { useSetHeaderAction } from '@/src/widgets/layout/header-action-context';
 import { MomentsPostForm } from '@/src/widgets/moments-post-form';
@@ -49,7 +52,12 @@ export function MomentsNewPage() {
   const handleSubmit = useCallback(
     async (values: MomentsPostFormValues) => {
       const data = await createPost(values);
-      void queryClient.invalidateQueries({ queryKey: momentsListRootQueryOptions().queryKey });
+      void Promise.all([
+        queryClient.invalidateQueries({ queryKey: momentsListRootQueryOptions().queryKey }),
+        queryClient.invalidateQueries({
+          queryKey: momentsListMetaPageRootQueryOptions().queryKey,
+        }),
+      ]);
       router.replace(`/moments/post/${data.postId}`);
     },
     [createPost, queryClient, router],

--- a/apps/web/src/pages/moments-user-feed/ui/MomentsUserFeedPage.tsx
+++ b/apps/web/src/pages/moments-user-feed/ui/MomentsUserFeedPage.tsx
@@ -6,8 +6,9 @@ import { useEffect, useMemo, useState } from 'react';
 import { useUserByIdQuery } from '@/src/entities/user';
 import {
   MOMENTS_LIST_CONFIG,
+  momentsListMetaPageRootQueryOptions,
   momentsListRootQueryOptions,
-  usePostsInfiniteQuery,
+  useMomentsFeedQuery,
 } from '@/src/features/moments-list';
 import {
   ProfileNicknameEditForm,
@@ -53,7 +54,9 @@ export function MomentsUserFeedPage({ authorId }: MomentsUserFeedPageProps) {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = usePostsInfiniteQuery(listParams);
+  } = useMomentsFeedQuery(listParams, {
+    isLoggedIn: currentUser !== undefined,
+  });
 
   const posts = useMemo(() => data?.pages?.flatMap((page) => page.posts) ?? [], [data]);
   const isEmpty = !isPostsLoading && posts.length === 0;
@@ -78,7 +81,10 @@ export function MomentsUserFeedPage({ authorId }: MomentsUserFeedPageProps) {
   const handleEditDone = () => {
     imageUpload.reset();
     setIsEditing(false);
-    void queryClient.invalidateQueries({ queryKey: momentsListRootQueryOptions().queryKey });
+    void Promise.all([
+      queryClient.invalidateQueries({ queryKey: momentsListRootQueryOptions().queryKey }),
+      queryClient.invalidateQueries({ queryKey: momentsListMetaPageRootQueryOptions().queryKey }),
+    ]);
   };
 
   const handleEditCancel = () => {

--- a/apps/web/src/pages/moments/index.ts
+++ b/apps/web/src/pages/moments/index.ts
@@ -1,1 +1,5 @@
+export {
+  getMomentsPageServerSideProps,
+  type MomentsPageProps,
+} from './model/get-moments-page-server-side-props';
 export { MomentsPage } from './ui/MomentsPage';

--- a/apps/web/src/pages/moments/model/get-moments-page-server-side-props.ts
+++ b/apps/web/src/pages/moments/model/get-moments-page-server-side-props.ts
@@ -1,0 +1,40 @@
+import type { GetServerSideProps } from 'next';
+
+import { fetchPublicPostListPageFn, type PostListResponseDataType } from '@/src/entities/post';
+import { MOMENTS_LIST_CONFIG } from '@/src/features/moments-list';
+import { normalizeStringList } from '@/src/shared/lib/list';
+
+export interface MomentsPageProps {
+  initialPageData?: PostListResponseDataType;
+  initialListParams: {
+    limit: number;
+    tags?: string[];
+  };
+}
+
+export const getMomentsPageServerSideProps: GetServerSideProps<MomentsPageProps> = async ({
+  query,
+}) => {
+  const normalizedTags = normalizeStringList(query.tag);
+  const initialListParams = {
+    limit: MOMENTS_LIST_CONFIG.PAGE_LIMIT,
+    tags: normalizedTags.length > 0 ? normalizedTags : undefined,
+  };
+
+  try {
+    const initialPageData = await fetchPublicPostListPageFn(initialListParams);
+
+    return {
+      props: {
+        initialPageData,
+        initialListParams,
+      },
+    };
+  } catch {
+    return {
+      props: {
+        initialListParams,
+      },
+    };
+  }
+};

--- a/apps/web/src/pages/moments/ui/MomentsPage.tsx
+++ b/apps/web/src/pages/moments/ui/MomentsPage.tsx
@@ -4,9 +4,11 @@ import { useCallback, useMemo } from 'react';
 import {
   MOMENTS_LIST_CONFIG,
   MOMENTS_LIST_MESSAGES,
-  usePostsInfiniteQuery,
+  type MomentsListQueryParams,
+  useMomentsFeedQuery,
 } from '@/src/features/moments-list';
 import { useOnboardingStatusQuery } from '@/src/features/onboarding-status';
+import { normalizeStringList } from '@/src/shared/lib/list';
 import { ROUTES } from '@/src/shared/routes';
 import { LoadableBoundary } from '@/src/shared/ui/boundary';
 import { useSetHeaderAction } from '@/src/widgets/layout/header-action-context';
@@ -15,25 +17,19 @@ import { MomentsCreateFab } from '@/src/widgets/moments-create-fab';
 import { MomentsList } from '@/src/widgets/moments-list';
 import { MomentsTagSearch } from '@/src/widgets/moments-tag-search';
 
+import type { MomentsPageProps } from '../model/get-moments-page-server-side-props';
 import { MomentsPageSkeleton } from './MomentsPage.skeleton';
 
-const DEFAULT_QUERY_PARAMS = {
+const DEFAULT_QUERY_PARAMS: MomentsListQueryParams = {
   limit: MOMENTS_LIST_CONFIG.PAGE_LIMIT,
 } as const;
 
-export function MomentsPage() {
+export function MomentsPage({ initialPageData, initialListParams }: MomentsPageProps) {
   const router = useRouter();
   const { data: onboardingStatus } = useOnboardingStatusQuery();
   const isLoggedIn = onboardingStatus !== 'unauthorized';
 
-  const searchTags = useMemo(() => {
-    const tagQuery = router.query.tag;
-    if (!tagQuery) return [];
-
-    const rawTags = Array.isArray(tagQuery) ? tagQuery : [tagQuery];
-    const normalizedTags = rawTags.map((tag) => tag.trim()).filter(Boolean);
-    return Array.from(new Set(normalizedTags));
-  }, [router.query.tag]);
+  const searchTags = useMemo(() => normalizeStringList(router.query.tag), [router.query.tag]);
 
   const listParams = useMemo(
     () => ({
@@ -44,7 +40,11 @@ export function MomentsPage() {
   );
 
   const { data, isLoading, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    usePostsInfiniteQuery(listParams, { isLoggedIn });
+    useMomentsFeedQuery(listParams, {
+      isLoggedIn,
+      initialPageData,
+      initialListParams,
+    });
 
   const posts = useMemo(() => data?.pages?.flatMap((page) => page.posts) ?? [], [data]);
   const isEmpty = !isLoading && posts.length === 0;
@@ -52,7 +52,7 @@ export function MomentsPage() {
 
   const handleSearch = useCallback(
     (tags: ReadonlyArray<string>) => {
-      const normalizedTags = [...tags].map((tag) => tag.trim()).filter(Boolean);
+      const normalizedTags = normalizeStringList(tags);
       const nextQuery = { ...router.query };
 
       if ('tag' in nextQuery) {
@@ -76,7 +76,7 @@ export function MomentsPage() {
   useSetHeaderAction(() => {
     if (isLoggedIn) return null;
     return <LoginButton />;
-  }, [isLoggedIn, router]);
+  }, [isLoggedIn]);
 
   return (
     <>

--- a/apps/web/src/shared/lib/list/index.ts
+++ b/apps/web/src/shared/lib/list/index.ts
@@ -1,2 +1,3 @@
 export type { ContiguousGroup } from './group-contiguous-items';
 export { groupContiguousItems } from './group-contiguous-items';
+export { normalizeStringList } from './normalize-string-list';

--- a/apps/web/src/shared/lib/list/normalize-string-list.ts
+++ b/apps/web/src/shared/lib/list/normalize-string-list.ts
@@ -1,0 +1,10 @@
+export function normalizeStringList(
+  values: ReadonlyArray<string> | string | null | undefined,
+): string[] {
+  if (!values) return [];
+
+  const rawValues = Array.isArray(values) ? values : [values];
+  const normalizedValues = rawValues.map((value) => value.trim()).filter(Boolean);
+
+  return Array.from(new Set(normalizedValues));
+}


### PR DESCRIPTION
🔷 Github Issue ID

- 작업한 내용에 해당하는 Issue 링크

📌 작업 내용 및 특이사항

## 요약
- `/`와 `/moments` 첫 페이지를 public `/posts` 기반 SSR로 렌더링하도록 변경
- 목록 base query와 meta page query를 분리하고, 로그인 종속 정보는 클라이언트에서 hydrate 하도록 구성
- user feed와 좋아요/생성/수정/삭제 이후 cache 동기화를 보강

## 영향
- 목록 화면에서는 meta 응답 중 `likeCount`, `isLiked` 중심으로 hydrate 함

## 확인 포인트
- `/`와 `/moments` 직접 진입 시 첫 페이지가 SSR HTML로 내려오는지
- 로그인 상태에서 첫 페이지와 추가 페이지의 `likeCount` / `isLiked`가 hydrate 되는지
- 좋아요, 게시글 생성/수정/삭제 후 hydrated meta cache 때문에 목록 값이 되돌아가지 않는지
- `/moments/[authorId]`도 동일한 meta hydrate 흐름으로 동작하는지


📚 참고사항

- PR 리뷰 과정에서 참고하면 좋을 내용들

Closes #
